### PR TITLE
topics_test: don't complain about github.com URLs.

### DIFF
--- a/test/topics_test.rb
+++ b/test/topics_test.rb
@@ -166,7 +166,8 @@ describe "topics" do
           end
 
           bad_github_variants.each do |wrong_github|
-            refute_includes line, wrong_github,
+            no_url_line = line.gsub "github.com"
+            refute_includes no_url_line, wrong_github,
                             'Always use correct capitalization when referring to "GitHub"'
           end
 


### PR DESCRIPTION
These shouldn't be capitalised to GitHub.com so let's just strip them from the test strings altogether.

As seen in #49 CC @shroudedcode and https://github.com/github/explore/pull/27 CC @nayafia @kentcdodds