### PR TITLE
Add a couple missing Oxford commas

### DIFF
--- a/test/topics_test.rb
+++ b/test/topics_test.rb
@@ -184,7 +184,7 @@ describe "topics" do
 
         assert_oxford_comma(text)
         assert_oxford_comma(metadata["short_description"]) if metadata
-        assert_oxford_comma(metadata["created_by"]) if metadata["created_by"]
+        assert_oxford_comma(metadata["created_by"]) if metadata
       end
     end
   end

--- a/test/topics_test.rb
+++ b/test/topics_test.rb
@@ -184,6 +184,7 @@ describe "topics" do
 
         assert_oxford_comma(text)
         assert_oxford_comma(metadata["short_description"]) if metadata
+        assert_oxford_comma(metadata["created_by"]) if metadata["created_by"]
       end
     end
   end

--- a/topics/amphp/index.md
+++ b/topics/amphp/index.md
@@ -8,4 +8,4 @@ short_description: Amp is a non-blocking concurrency framework for PHP.
 topic: amphp
 url: https://amphp.org/
 ---
-Amp is a non-blocking concurrency framework for PHP. It provides an event loop, promises and streams as a base for asynchronous programming.
+Amp is a non-blocking concurrency framework for PHP. It provides an event loop, promises, and streams as a base for asynchronous programming.

--- a/topics/sitecore/index.md
+++ b/topics/sitecore/index.md
@@ -1,6 +1,6 @@
 ---
 aliases: xdb
-created_by: Michael Seifert, Ole Sas Thrane and Jakob Christensen
+created_by: Michael Seifert, Ole Sas Thrane, and Jakob Christensen
 display_name: Sitecore
 github_url: https://github.com/sitecore
 logo: sitecore.png


### PR DESCRIPTION
This branch adds some commas to suit our styleguide and also checks the 'created_by' field for Oxford commas.