### PR TITLE
Update React Homepage URL

### DIFF
--- a/topics/react/index.md
+++ b/topics/react/index.md
@@ -9,7 +9,7 @@ released: March 2013
 short_description: React is an open source JavaScript library used for designing user
   interfaces.
 topic: react
-url: https://facebook.github.io/react/
+url: https://reactjs.org/
 wikipedia_url: https://en.wikipedia.org/wiki/React_(JavaScript_library)
 ---
 React makes it simple to develop interactive user interfaces. It uses the Model View Controller (MVC) concept to manage individual pages in your web application.


### PR DESCRIPTION
https://reactjs.org/ is now the new homepage.

- [x] I followed the contributing guidelines: https://github.com/github/explore/blob/master/CONTRIBUTING.md

I am:
  - [x] Suggesting edits to an existing Topic page
  - [ ] Curating a new Topic page

***********EDITING AN EXISTING TOPIC PAGE************

I'm suggesting these edits to an existing topic:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288)
- [x] Content (and my changes are in `index.md`)

Please explain why these changes are necessary:

[On September 29](https://twitter.com/reactjs/status/913797391307833344) the React homepage got relocated to https://reactjs.org/

************CURATING A NEW TOPIC PAGE************

- [ ] I've formatted my changes as a new folder directory, named for the topic as it appears in the URL on GitHub (e.g. `https://github.com/topics/[NAME]`)
- [ ] My folder contains a `*.png` image (if applicable) and `index.md`
- [ ] All required fields in my `index.md` conform to the Style Guide and API docs: https://github.com/github/explore/tree/master/docs

Please explain why you think this Topic page should be curated:

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**
