### PR TITLE
Test for valid GitHub and Wikipedia URLs

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,6 @@
 require "minitest/autorun"
 require "fastimage"
+require "uri"
 require "yaml"
 
 IMAGE_EXTENSIONS = %w[.jpg .jpeg .png].freeze

--- a/test/topics_test.rb
+++ b/test/topics_test.rb
@@ -17,6 +17,15 @@ describe "topics" do
         end
       end
 
+      it "has a valid Wikipedia URL" do
+        metadata = metadata_for(topic)
+
+        if metadata && metadata["wikipedia_url"]
+          uri = URI.parse(metadata["wikipedia_url"])
+          assert_match /wikipedia\.org/, uri.host, "wikipedia_url should point to wikipedia.org"
+        end
+      end
+
       it "has valid aliases" do
         aliases = aliases_for(topic)
 

--- a/test/topics_test.rb
+++ b/test/topics_test.rb
@@ -8,21 +8,22 @@ describe "topics" do
       end
 
       it "has a valid GitHub URL" do
-        metadata = metadata_for(topic)
+        metadata = metadata_for(topic) || {}
 
-        if metadata && metadata["github_url"]
+        if metadata["github_url"]
           uri = URI.parse(metadata["github_url"])
           assert_includes ["www.github.com", "github.com"], uri.host,
-            "github_url should point to either www.github.com or github.com"
+                          "github_url should point to either www.github.com or github.com"
         end
       end
 
       it "has a valid Wikipedia URL" do
-        metadata = metadata_for(topic)
+        metadata = metadata_for(topic) || {}
 
-        if metadata && metadata["wikipedia_url"]
+        if metadata["wikipedia_url"]
           uri = URI.parse(metadata["wikipedia_url"])
-          assert_match /wikipedia\.org/, uri.host, "wikipedia_url should point to wikipedia.org"
+          regex = /wikipedia\.org/
+          assert_match regex, uri.host, "wikipedia_url should point to wikipedia.org"
         end
       end
 

--- a/test/topics_test.rb
+++ b/test/topics_test.rb
@@ -7,6 +7,16 @@ describe "topics" do
         assert valid_topic?(topic), invalid_topic_message(topic)
       end
 
+      it "has a valid GitHub URL" do
+        metadata = metadata_for(topic)
+
+        if metadata && metadata["github_url"]
+          uri = URI.parse(metadata["github_url"])
+          assert_includes ["www.github.com", "github.com"], uri.host,
+            "github_url should point to either www.github.com or github.com"
+        end
+      end
+
       it "has valid aliases" do
         aliases = aliases_for(topic)
 
@@ -183,8 +193,10 @@ describe "topics" do
         end
 
         assert_oxford_comma(text)
-        assert_oxford_comma(metadata["short_description"]) if metadata
-        assert_oxford_comma(metadata["created_by"]) if metadata
+        if metadata
+          assert_oxford_comma(metadata["short_description"])
+          assert_oxford_comma(metadata["created_by"])
+        end
       end
     end
   end

--- a/topics/github-api/index.md
+++ b/topics/github-api/index.md
@@ -1,7 +1,6 @@
 ---
 created_by: GitHub
 display_name: GitHub API
-github_url: https://developer.github.com/
 related: github, github-client, github-app, api, api-rest, graphql
 short_description: The GitHub API allows you to build applications that integrate with GitHub.
 topic: github-api


### PR DESCRIPTION
This adds a couple tests to ensure the "github_url" and "wikipedia_url" fields look somewhat correct. They must be parseable as URIs and have an expected host.