### PR TITLE
Fix incorrect perl logo file name

### DIFF
--- a/test/topics_test.rb
+++ b/test/topics_test.rb
@@ -91,14 +91,20 @@ describe "topics" do
         assert File.file?(path), "expected #{path} to be a file"
       end
 
-      it "does not specify an image if none exists" do
-        paths = image_paths_for(topic)
+      it "uses the right file name for specified logo" do
         metadata = metadata_for(topic)
-        no_image_exists = paths.all? { |path| !File.exist?(path) }
 
-        if no_image_exists && metadata
-          refute_includes metadata.keys, "logo",
-                          "should not specify a logo '#{metadata['logo']}' if no image exists"
+        if metadata
+          paths = image_paths_for(topic)
+          valid_file_names = paths.map { |path| File.basename(path) }
+          error_message = if valid_file_names.empty?
+                            "should not specify logo #{metadata['logo']} when file does not exist"
+                          else
+                            "logo should be #{valid_file_names.join(' or ')}, but was " +
+                              metadata["logo"].to_s
+                          end
+          assert !metadata.key?("logo") || valid_file_names.include?(metadata["logo"]),
+                 error_message
         end
       end
 

--- a/topics/perl/index.md
+++ b/topics/perl/index.md
@@ -3,7 +3,7 @@ aliases: perl5, perl6
 created_by: Larry Wall
 display_name: Perl
 github_url: https://github.com/Perl/perl5
-logo: perl5.png
+logo: perl.png
 related: perl-script
 released: December 18, 1987
 short_description: Perl is a highly capable and feature-rich programming language.


### PR DESCRIPTION
This branch:

- Improves our tests so that if you specify a logo using an incorrect file name, it will fail. For example, the perl topic said `logo: perl5.png`, but the file in the perl/ directory was actually perl.png.
- Fixes the perl topic to use the right file name for its logo.