### PR TITLE
Change aliases, related topics on mahapps topic

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -3,7 +3,14 @@
 If you're making edits to a topic page, the following fields are available for use. Not all fields are required.
 
 ### aliases
-(if applicable) Synonyms for the topic name. For example, `react` and `reactjs` are aliases.
+(if applicable) Synonyms for the topic name. For example, `react` and `reactjs` are aliases. You
+should only list an alias for your topic if the majority of repositories using that alias are
+referring to the same subject matter as the topic. You should not list another topic as an alias
+if the alias is a superset of your topic.
+
+For example, `api` makes sense in the `related` field for the `graphql` topic, but because many
+repositories tagged with `api` are _not_ be associated with `graphql`, `api` does not make sense
+in the `aliases` field for `graphql`.
 
 Each alias must be formatted like that topic's `topic` field (same as the URL slug). Acceptable formatting:
 

--- a/topics/graphql/index.md
+++ b/topics/graphql/index.md
@@ -1,10 +1,11 @@
 ---
+aliases: graphql-client, graphql-api, graphql-schema, graphql-query, graphql-server
 created_by: Facebook
 display_name: GraphQL
 github_url: https://github.com/graphql
 logo: graphql.png
 released: 2015
-related: api, rest, graphql-client, graphql-api, graphql-schema, graphql-query, graphql-server
+related: api, rest
 short_description: GraphQL is a query language for APIs and a runtime for fulfilling those queries with your existing data.
 topic: graphql
 url: http://graphql.org/

--- a/topics/mahapps/index.md
+++ b/topics/mahapps/index.md
@@ -1,9 +1,10 @@
 ---
-aliases: mahapps-metro, metro
+aliases: mahapps-metro
 created_by: Paul Jenkins
 display_name: MahApps.Metro
 github_url: https://github.com/MahApps/MahApps.Metro
 logo: mahapps.png
+related: metro
 released: January 29, 2011
 short_description: A toolkit for creating metro-modern-style WPF applications.
 topic: mahapps

--- a/topics/mahapps/index.md
+++ b/topics/mahapps/index.md
@@ -4,7 +4,7 @@ created_by: Paul Jenkins
 display_name: MahApps.Metro
 github_url: https://github.com/MahApps/MahApps.Metro
 logo: mahapps.png
-related: metro
+related: metro, wpf
 released: January 29, 2011
 short_description: A toolkit for creating metro-modern-style WPF applications.
 topic: mahapps

--- a/topics/material-design/index.md
+++ b/topics/material-design/index.md
@@ -7,4 +7,4 @@ topic: material-design
 url: https://material.io/
 wikipedia_url: https://en.wikipedia.org/wiki/Material_Design
 ---
-Material design is a design language developed by Google. It makes use of grid based layouts, responsive animation and transitioning.
+Material design is a design language developed by Google. It makes use of grid-based layouts, responsive animation, and transitioning.

--- a/topics/material-design/index.md
+++ b/topics/material-design/index.md
@@ -4,6 +4,7 @@ display_name: Material design
 short_description: Material design is a unified system of theory and tools for creating
   digital experiences developed by Google.
 topic: material-design
+related: material
 url: https://material.io/
 wikipedia_url: https://en.wikipedia.org/wiki/Material_Design
 ---


### PR DESCRIPTION
This makes "metro" a related topic to "mahapps" instead of an alias. That way the mahapps curated content will not show on /topics/metro, as not every repository using the metro topic is related to mahapps.

This also adds "wpf" as a related topic to "mahapps".