### PR TITLE
Add more related topics

### DIFF
--- a/topics/bash/index.md
+++ b/topics/bash/index.md
@@ -4,6 +4,7 @@ created_by: Brian Fox
 display_name: Bash
 github_url: https://github.com/gitGNU/gnu_bash
 logo: bash.png
+related: shell
 released: June 8, 1989
 short_description: Bash is a shell and command language interpreter for the GNU operating
   system.

--- a/topics/c/index.md
+++ b/topics/c/index.md
@@ -3,6 +3,7 @@ aliases: c-language
 created_by: Dennis Ritchie
 display_name: C
 logo: c.png
+related: language
 released: '1972'
 short_description: C is a general purpose programming language that first appeared
   in 1972.

--- a/topics/clojure/index.md
+++ b/topics/clojure/index.md
@@ -1,9 +1,10 @@
 ---
+aliases: clj
 created_by: Rich Hickey
 display_name: Clojure
 github_url: https://github.com/clojure
 logo: clojure.png
-related: clojurescript, clj, cljs
+related: clojurescript, cljs, language
 released: October 16, 2007
 short_description: Clojure is a dynamic, general-purpose programming language.
 topic: clojure

--- a/topics/csharp/index.md
+++ b/topics/csharp/index.md
@@ -3,6 +3,7 @@ aliases: c-sharp, csharp-code, csharp7, csharp-core, csharp6, csharp-resources
 created_by: Anders Hejlsberg
 display_name: C#
 logo: csharp.png
+related: language, dotnet
 released: June 2000
 short_description: C# (C sharp) is an object-oriented programming language by Microsoft.
 topic: csharp

--- a/topics/elixir/index.md
+++ b/topics/elixir/index.md
@@ -3,6 +3,7 @@ created_by: José Valim
 display_name: Elixir
 github_url: https://github.com/elixir-lang
 logo: elixir.png
+related: language, erlang
 released: September 8, 2014
 short_description: Elixir is a dynamic, functional language designed for building scalable and maintainable applications.
 topic: elixir

--- a/topics/elixir/index.md
+++ b/topics/elixir/index.md
@@ -3,7 +3,7 @@ created_by: José Valim
 display_name: Elixir
 github_url: https://github.com/elixir-lang
 logo: elixir.png
-related: language, erlang
+related: language, erlang, ruby
 released: September 8, 2014
 short_description: Elixir is a dynamic, functional language designed for building scalable and maintainable applications.
 topic: elixir

--- a/topics/go/index.md
+++ b/topics/go/index.md
@@ -4,6 +4,7 @@ created_by: Robert Griesemer, Rob Pike, Ken Thompson
 display_name: Go
 github_url: https://github.com/golang/go
 logo: go.png
+related: language, c
 released: November 10, 2009
 short_description: Go is a programming language built to resemble a simplified version
   of the C programming language.

--- a/topics/julia/index.md
+++ b/topics/julia/index.md
@@ -4,6 +4,7 @@ created_by: Jeff Bezanson, Stefan Karpinski, Viral B. Shah, Alan Edelman
 display_name: The Julia Language
 github_url: https://github.com/JuliaLang
 logo: julia.png
+related: language
 released: February 14, 2012
 short_description: Julia is a high-level, high-performance dynamic programming language for numerical computing.
 topic: julia

--- a/topics/laravel/index.md
+++ b/topics/laravel/index.md
@@ -4,6 +4,7 @@ created_by: Taylor Otwell
 display_name: Laravel
 github_url: https://github.com/laravel
 logo: laravel.png
+related: framework, php
 released: June 2011
 short_description: Laravel is a PHP framework.
 topic: laravel

--- a/topics/perl/index.md
+++ b/topics/perl/index.md
@@ -1,10 +1,10 @@
 ---
-aliases: perl5, perl6
+aliases: perl5, perl6, perl-script
 created_by: Larry Wall
 display_name: Perl
 github_url: https://github.com/Perl/perl5
 logo: perl.png
-related: perl-script
+related: language
 released: December 18, 1987
 short_description: Perl is a highly capable and feature-rich programming language.
 topic: perl

--- a/topics/php/index.md
+++ b/topics/php/index.md
@@ -4,6 +4,7 @@ created_by: Rasmus Lerdorf
 display_name: PHP
 github_url: https://github.com/php
 logo: php.png
+related: language
 released: June 8, 1995
 short_description: PHP is a scripting language that works particularly well for server-side
   web development.

--- a/topics/python/index.md
+++ b/topics/python/index.md
@@ -4,6 +4,7 @@ created_by: Guido van Rossum
 display_name: Python
 github_url: https://github.com/python
 logo: python.png
+related: language, ruby
 released: February 20, 1991
 short_description: Python is a dynamically typed programming language.
 topic: python

--- a/topics/r/index.md
+++ b/topics/r/index.md
@@ -2,6 +2,7 @@
 created_by: Ross Ihaka, Robert Gentleman
 display_name: R
 logo: r.png
+related: language
 released: August 1993
 short_description: R is a free programming language and software environment for statistical
   computing and graphics.

--- a/topics/rails/index.md
+++ b/topics/rails/index.md
@@ -1,5 +1,5 @@
 ---
-aliases: rails5, rails-application, ruby-on-rails, rails4, rubyonrails
+aliases: rails5, rails-application, ruby-on-rails, rails4, rubyonrails, rails-tutorial
 created_by: David Heinemeier Hansson
 display_name: Rails
 github_url: https://github.com/rails

--- a/topics/react-native/index.md
+++ b/topics/react-native/index.md
@@ -4,6 +4,7 @@ created_by: Facebook
 display_name: React Native
 github_url: https://github.com/facebook/react-native
 logo: react-native.png
+related: reactjs, react-js
 released: January 2015
 short_description: React Native is a JavaScript mobile framework developed by Facebook.
 topic: react-native

--- a/topics/react-native/index.md
+++ b/topics/react-native/index.md
@@ -4,7 +4,7 @@ created_by: Facebook
 display_name: React Native
 github_url: https://github.com/facebook/react-native
 logo: react-native.png
-related: reactjs, react-js
+related: reactjs
 released: January 2015
 short_description: React Native is a JavaScript mobile framework developed by Facebook.
 topic: react-native

--- a/topics/react/index.md
+++ b/topics/react/index.md
@@ -4,7 +4,7 @@ created_by: Jordan Walke
 display_name: React
 github_url: https://github.com/facebook/react
 logo: react.png
-related: vue, angular, react-native-app, react-native
+related: vue, angular, react-native
 released: March 2013
 short_description: React is an open source JavaScript library used for designing user
   interfaces.

--- a/topics/react/index.md
+++ b/topics/react/index.md
@@ -4,7 +4,7 @@ created_by: Jordan Walke
 display_name: React
 github_url: https://github.com/facebook/react
 logo: react.png
-related: vue, angular
+related: vue, angular, react-native-app, react-native
 released: March 2013
 short_description: React is an open source JavaScript library used for designing user
   interfaces.

--- a/topics/redux/index.md
+++ b/topics/redux/index.md
@@ -3,6 +3,7 @@ created_by: Dan Abramov and Andrew Clark
 display_name: Redux
 github_url: https://github.com/reactjs/redux/
 logo: redux.png
+related: javascript, react
 released: June 2, 2015
 short_description: Redux is a predictable state container for JavaScript apps.
 topic: redux

--- a/topics/rest-api/index.md
+++ b/topics/rest-api/index.md
@@ -1,6 +1,7 @@
 ---
-aliases: rest-api-tutorial
+aliases: rest, rest-api-tutorial
 display_name: REST API
+related: api, graphql-api
 short_description: A representational state transfer (REST) API is a way to provide
   compatibility between computer systems on the internet.
 topic: rest-api

--- a/topics/ruby/index.md
+++ b/topics/ruby/index.md
@@ -3,6 +3,7 @@ created_by: Yukihiro Matsumoto
 display_name: Ruby
 github_url: https://github.com/ruby/ruby
 logo: ruby.png
+related: rails, language, python
 released: December 21, 1995
 short_description: Ruby is a scripting language designed for simplified object-oriented
   programming.

--- a/topics/rust/index.md
+++ b/topics/rust/index.md
@@ -4,6 +4,7 @@ created_by: Graydon Hoare
 display_name: Rust
 github_url: https://github.com/rust-lang
 logo: rust.png
+related: language, c-plus-plus
 released: '2010'
 short_description: Rust is a systems programming language created by Mozilla.
 topic: rust

--- a/topics/shell/index.md
+++ b/topics/shell/index.md
@@ -2,6 +2,7 @@
 aliases: shell-script, shell-scripts, shellscript, shellcode
 created_by: Glenda Schroeder
 display_name: Shell
+related: bash
 released: '1965'
 short_description: A shell is a command-line tool, designed to be run by the Unix
   shell.

--- a/topics/swift/index.md
+++ b/topics/swift/index.md
@@ -1,7 +1,7 @@
 ---
 topic: swift
 aliases: swift3, swift-3, swift4, swift-4, swift-language
-related: objective-c
+related: objective-c, language
 display_name: Swift
 created_by: Apple
 logo: swift.png

--- a/topics/typescript/index.md
+++ b/topics/typescript/index.md
@@ -4,6 +4,7 @@ created_by: Microsoft
 display_name: TypeScript
 github_url: https://github.com/Microsoft/TypeScript
 logo: typescript.png
+related: language, javascript
 released: October 1, 2012
 short_description: TypeScript is a typed superset of JavaScript that compiles to plain JavaScript.
 topic: typescript


### PR DESCRIPTION
- [x] I followed the contributing guidelines: https://github.com/github/explore/blob/master/CONTRIBUTING.md

I am:
  - [x] Suggesting edits to an existing Topic page
  - [ ] Curating a new Topic page

***********EDITING AN EXISTING TOPIC PAGE************

I'm suggesting these edits to an existing topic:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288)
- [x] Content (and my changes are in `index.md`)

Please explain why these changes are necessary:

For the react changes: if someone lands on /topics/react, they might not know react-native is a thing. Oppositely, if they land on /topics/react-native, it'd be good to link back to react so they can find out about the base framework.

I also added related topics to connect languages, and tie topics for programming languages back to the general 'languages' topic. I think this will let users branch out to discover new languages.