### PR TITLE
Use Amp's first release instead of first stable release

### DIFF
--- a/topics/amphp/index.md
+++ b/topics/amphp/index.md
@@ -3,7 +3,7 @@ related: php
 created_by: Daniel Lowrey
 display_name: Amp
 github_url: https://github.com/amphp
-released: July 27, 2015
+released: August 05, 2013
 short_description: Amp is a non-blocking concurrency framework for PHP.
 topic: amphp
 url: https://amphp.org/


### PR DESCRIPTION
- [x] I followed the contributing guidelines: https://github.com/github/explore/blob/master/CONTRIBUTING.md

I am:
  - [x] Suggesting edits to an existing Topic page
  - [ ] Curating a new Topic page

***********EDITING AN EXISTING TOPIC PAGE************

I'm suggesting these edits to an existing topic:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288)
- [x] Content (and my changes are in `index.md`)

Please explain why these changes are necessary: Initially I put the first stable release date there instead of the first release.