### PR TITLE
Add test to find bad comma position in 'released' field

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -42,7 +42,7 @@ Each related topic must be formatted like that topic's `topic` field (same as th
 * At most 35 characters long
 
 ### released
-(if applicable) Date of first release. Formatted as `MONTH DD, YYYY`
+(if applicable) Date of first release. Formatted as `MONTH DD, YYYY`, `MONTH YYYY`, or just `YYYY`.
 
 ### short_description
 (required) A short description of the topic, which will be used on the Explore homepage, Topics subpage, and other preview areas. Must be 130 characters or less. Emoji are not allowed.

--- a/test/topics_test.rb
+++ b/test/topics_test.rb
@@ -39,12 +39,17 @@ describe "topics" do
       it "uses the right format for 'released'" do
         metadata = metadata_for(topic) || ""
 
-        if metadata["released"]
-          text = metadata["released"].to_s.gsub(/[\d+,\s]/, "").strip
+        if released = metadata["released"]
+          text = released.to_s.gsub(/[\d+,\s]/, "").strip
 
           unless text.empty?
             assert_includes ENGLISH_MONTHS, text,
                             "please format 'released' like MONTH DD, YYYY with the month in English"
+          end
+
+          ENGLISH_MONTHS.each do |month|
+            refute_includes released.to_s, "#{month},",
+                            "should not include a comma after the month name"
           end
         end
       end

--- a/topics/wagtail/index.md
+++ b/topics/wagtail/index.md
@@ -5,7 +5,7 @@ created_by: Torchbox
 display_name: Wagtail
 github_url: https://github.com/wagtail
 logo: wagtail.png
-released: February, 2014
+released: February 2014
 short_description: Wagtail is an open source CMS written in Python and
   built on the Django web framework.
 topic: wagtail


### PR DESCRIPTION
This adds a new test to ensure we don't have commas after month names in the 'released' field. It also removes such a comma from the 'wagtail' topic.