### PR TITLE
P2P topic

### DIFF
--- a/topics/p2p/index.md
+++ b/topics/p2p/index.md
@@ -1,0 +1,9 @@
+---
+aliases: peer2peer, peer-to-peer
+display_name: P2P
+related: decentralized, distributed, peer
+short_description: Peer-to-Peer applications are decentralized or distributed.
+topic: p2p 
+wikipedia_url: https://en.wikipedia.org/wiki/Peer-to-peer
+---
+Peer-to-Peer (P2P) applications share resources and communicate in a decentralized or distributed architecture. Often, application nodes communicate directly with each other or cooperate to do work which benefits other nodes or the overall P2P system. In a pure P2P system, there is no distinction betweek client and server.


### PR DESCRIPTION
- [x] I followed the contributing guidelines: https://github.com/github/explore/blob/master/CONTRIBUTING.md

I am:
  - [x] Curating a new Topic page

- [x] I've formatted my changes as a new folder directory, named for the topic as it appears in the URL on GitHub (e.g. `https://github.com/topics/[NAME]`)
- [x] My folder contains a `*.png` image (if applicable) and `index.md`
- [x] All required fields in my `index.md` conform to the Style Guide and API docs: https://github.com/github/explore/tree/master/docs

Please explain why you think this Topic page should be curated:

The topic is well used, [465 repos currently](https://github.com/topics/p2p). I thought of this because it's linked (well, a search for the topic is) in https://github.com/blog/2396-join-github-in-support-of-the-open-internet-again

I skimmed https://tools.ietf.org/html/rfc5694 to get ideas for the descriptions. I didn't include an image since the first thing that [comes to mind](https://www.rand.org/content/dam/rand/pubs/research_memoranda/2006/RM3420.pdf#page=16) is still subject to copyright and not licensed as far as I know and a quick search didn't turn up a great substitute.
