### PR TITLE
Remove second windows 10 alias

### DIFF
--- a/topics/windows/index.md
+++ b/topics/windows/index.md
@@ -1,5 +1,5 @@
 ---
-aliases: windows-10, windows10, windows-7, windows-8
+aliases: windows-10, windows-7, windows-8
 created_by: Microsoft Corporation
 display_name: Windows
 github_url: https://github.com/Microsoft


### PR DESCRIPTION
- [x] I followed the contributing guidelines: https://github.com/github/explore/blob/master/CONTRIBUTING.md

I am:
  - [x] Suggesting edits to an existing Topic page
  - [ ] Curating a new Topic page

I'm suggesting these edits to an existing topic:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288)
- [x] Content (and my changes are in `index.md`)

Please explain why these changes are necessary:
For some reason, Windows 10 was listed as an alias a second time but without a hyphen.