### PR TITLE
Typo in index.md

### DIFF
--- a/topics/flask/index.md
+++ b/topics/flask/index.md
@@ -9,4 +9,4 @@ topic: flask
 url: http://flask.pocoo.org/
 wikipedia_url: https://en.wikipedia.org/wiki/Flask_(web_framework)
 ---
-Flask is a web framework for Python, based on the Wekzeug toolkit.
+Flask is a web framework for Python, based on the Werkzeug toolkit.


### PR DESCRIPTION
This is just a small typo in the name of https://github.com/pallets/werkzeug