### PR TITLE
Remove Micro-controller references from RPi

### DIFF
--- a/topics/raspberry-pi/index.md
+++ b/topics/raspberry-pi/index.md
@@ -5,9 +5,9 @@ display_name: Raspberry Pi
 github_url: https://github.com/raspberrypi
 logo: raspberry-pi.png
 released: July 2011
-short_description: A Raspberry Pi is a piece of hardware called a micro-controller.
+short_description: The Raspberry Pi is a popular single-board computer.
 topic: raspberry-pi
 url: https://www.raspberrypi.org/
 wikipedia_url: https://en.wikipedia.org/wiki/Raspberry_Pi
 ---
-A Raspberry Pi is a piece of hardware, called a micro-controller, developed promote the teaching of basic computer science in schools. The use of Raspberry Pi devices ranges from robotics to home automation. Raspberry Pi is one of the most popular micro-controllers on the market.
+The Raspberry Pi is a popular single-board computer designed to promote the teaching of computer science in schools. The use of the Raspberry Pi computer ranges from robotics to home automation. Many variations of the Raspberry Pi exist, such as the Raspberry Pi Zero, which is smaller than the more powerful Raspberry Pi 3.


### PR DESCRIPTION
The Raspberry Pi is a single-board computer, not a microcontroller.
Additionally reworded the sentences for better reading, and added that there are difference variations of the Pi available.

- [x] I followed the contributing guidelines: https://github.com/github/explore/blob/master/CONTRIBUTING.md

I am:
  - [x] Suggesting edits to an existing Topic page
  - [ ] Curating a new Topic page

***********EDITING AN EXISTING TOPIC PAGE************

I'm suggesting these edits to an existing topic:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288)
- [x] Content (and my changes are in `index.md`)

Please explain why these changes are necessary:
Incorrect information throughout.

************CURATING A NEW TOPIC PAGE************

- [ ] I've formatted my changes as a new folder directory, named for the topic as it appears in the URL on GitHub (e.g. `https://github.com/topics/[NAME]`)
- [ ] My folder contains a `*.png` image (if applicable) and `index.md`
- [ ] All required fields in my `index.md` conform to the Style Guide and API docs: https://github.com/github/explore/tree/master/docs

Please explain why you think this Topic page should be curated:

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**
