### PR TITLE
Add test exception for 'Raspberry Pi 3'

### DIFF
--- a/test/topics_test.rb
+++ b/test/topics_test.rb
@@ -324,7 +324,7 @@ describe "topics" do
 
           match = line.match(/\b(\w+)\s\d[.,;:\s]/)
           if match
-            allowed_words_before_numbers = %w[Perl]
+            allowed_words_before_numbers = %w[Perl Pi]
             assert_includes allowed_words_before_numbers, match[1],
                             'Write out "one" and every number less than 10, except when they ' \
                             "follow one of: #{allowed_words_before_numbers.join(', ')}"


### PR DESCRIPTION
This is a fix for a failing test seen in https://github.com/github/explore/pull/147. We normally want numbers less than ten to be written out, but "Raspberry Pi 3" is the correct name, so the test shouldn't complain it's not "Raspberry Pi Three."