### PR TITLE
Consistently capitalise ECMAScript

### DIFF
--- a/topics/es6/index.md
+++ b/topics/es6/index.md
@@ -5,7 +5,7 @@ display_name: ES6
 github_url: https://github.com/tc39
 logo: es6.png
 released: '1997'
-short_description: EcmaScript 6 is the sixth release of the ECMAScript language.
+short_description: ECMAScript 6 is the sixth release of the ECMAScript language.
 topic: es6
 url: http://www.ecma-international.org/
 wikipedia_url: https://en.wikipedia.org/wiki/ECMAScript


### PR DESCRIPTION
- [x] I followed the contributing guidelines: https://github.com/github/explore/blob/master/CONTRIBUTING.md

I am:
  - [x] Suggesting edits to an existing Topic page
  - [ ] Curating a new Topic page

I'm suggesting these edits to an existing topic:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288)
- [x] Content (and my changes are in `index.md`)

Please explain why these changes are necessary:

ECMAScript is the canonical capitalisation. It should be used consistently.