### PR TITLE
Updated progressive web apps topic

### DIFF
--- a/topics/pwa/index.md
+++ b/topics/pwa/index.md
@@ -1,13 +1,12 @@
 ---
 aliases: progressive-web-app, progressive-web-apps
-created_by: Alex Russell and Frances Berriman
 display_name: PWA
 logo: pwa.png
 related: service-worker, offline, notifications, app-shell, manifest
 released: 2015
 short_description: Progressive Web Apps are traditional web sites that are enhanced with native like features.
 topic: pwa
-url: https://developers.google.com/web/progressive-web-apps/
+url: https://developer.mozilla.org/en-US/Apps/Progressive
 wikipedia_url: https://en.wikipedia.org/wiki/Progressive_web_app
 ---
 Progressive Web Apps start with a traditional web site/application and progressively enhance with modern features. When sites are [secure](https://developers.google.com/web/fundamentals/security/encrypt-in-transit/why-https) they can leverage  [ServiceWorkers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) to provider users with offline support, [Push notifications](https://developer.mozilla.org/en-US/docs/Web/API/Push_API) can help re-engage users, and [Web App Manifests](https://developer.mozilla.org/en-US/docs/Web/Manifest) let users install PWAs alongside native apps.


### PR DESCRIPTION
- [x] I followed the contributing guidelines: https://github.com/github/explore/blob/master/CONTRIBUTING.md

I am:
  - [x] Suggesting edits to an existing Topic page
  - [ ] Curating a new Topic page

***********EDITING AN EXISTING TOPIC PAGE************

I'm suggesting these edits to an existing topic:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288)
- [x] Content (and my changes are in `index.md`)

Please explain why these changes are necessary:

As someone who has been involved with the creation of progressive web apps since day one (I wrote the O'Reilly book [Building Progressive Web Apps](https://pwabook.com)), I think the current topic needs two changes:

- Remove the `created_by` field which only listed two people as the creators of progressive web apps. While Francis and Alex were immensely influential for the creation of progressive web apps and service workers in particular, and while I personally adore and have been floored by the depth of Alex's intelligence and vision in every single interaction I ever had with him (I never had a chance to meet Francis), I think it isn't fair to attribute to two people what is an industry-wide effort by dozens of people who have worked day and night to make this happen.

- I would also suggest replacing the link to Google's web site (which seems to suggest it is the "official website" of progressive web apps) with a link maintained by many different browser vendors (such as MDN). Again, while I absolutely admire Google's efforts to help further the open Web, and believe they have been one of (if not the most) critical elements in making progressive web apps a success, this was an industry wide effort with a lot of resources put in by many companies. If anything, the appearance of progressive web apps being a Google thing has been detrimental to their adoption.

************CURATING A NEW TOPIC PAGE************

- [ ] I've formatted my changes as a new folder directory, named for the topic as it appears in the URL on GitHub (e.g. `https://github.com/topics/[NAME]`)
- [ ] My folder contains a `*.png` image (if applicable) and `index.md`
- [ ] All required fields in my `index.md` conform to the Style Guide and API docs: https://github.com/github/explore/tree/master/docs

Please explain why you think this Topic page should be curated:

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**
