### PR TITLE
Update renamed and deleted repos

### DIFF
--- a/collections/social-impact/index.md
+++ b/collections/social-impact/index.md
@@ -2,7 +2,7 @@
 items:
  - hotosm/osm-tasking-manager2
  - RefugeRestrooms/refugerestrooms
- - julianguyen/ifme
+ - ifmeorg/ifme
  - GliaX/Stethoscope
  - HospitalRun/hospitalrun-frontend
  - OptiKey/OptiKey

--- a/collections/web-games/index.md
+++ b/collections/web-games/index.md
@@ -6,7 +6,6 @@ items:
  - AlexNisnevich/untrusted
  - doublespeakgames/adarkroom
  - Hextris/hextris
- - Q42/0hh1
 display_name: Web games
 created_by: leereilly
 ---


### PR DESCRIPTION
Two updates here:

* [julianguyen/ifme](http://github.com/julianguyen/ifme) has moved to an organization at [ifmeorg/ifme](http://github.com/ifmeorg/ifme)
* [Q43/0hh1](http://github.com/Q43/0hh1) seems to have been deleted