### PR TITLE
Don't pin gem versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 source "https://rubygems.org"
 
 group :test do
-  gem "fastimage", "~> 2.1.0"
-  gem "minitest", "~> 5.10.3"
+  gem "fastimage"
+  gem "minitest"
   gem "rake"
-  gem "rubocop", "~> 0.50.0"
-  gem "safe_yaml", "~> 1.0.4"
+  gem "rubocop"
+  gem "safe_yaml"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,11 +26,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  fastimage (~> 2.1.0)
-  minitest (~> 5.10.3)
+  fastimage
+  minitest
   rake
-  rubocop (~> 0.50.0)
-  safe_yaml (~> 1.0.4)
+  rubocop
+  safe_yaml
 
 BUNDLED WITH
-   1.15.4
+   1.16.1


### PR DESCRIPTION
This isn't necessary unless we have known breakages. `Gemfile.lock` will take care of pinning the versions for us.