### PR TITLE
collections/pixel-art-tools: add missing image.

### DIFF
--- a/collections/pixel-art-tools/index.md
+++ b/collections/pixel-art-tools/index.md
@@ -7,5 +7,6 @@ items:
  - https://github.com/gmattie/Data-Pixels/
 display_name: Pixel Art Tools
 created_by: leereilly
+image: pixel-art-tools.png
 ---
 Creating pixel art for fun or animated sprites for a game? The digital artist in you will love these apps and tools!


### PR DESCRIPTION
The image file is there but it's not in the YAML.