### PR TITLE
collections/github-browser-extensions: fix renamed repo.

### DIFF
--- a/collections/github-browser-extensions/index.md
+++ b/collections/github-browser-extensions/index.md
@@ -10,7 +10,6 @@ items:
  - jasonlong/isometric-contributions
  - ForbesLindesay/github-real-names
  - benbalter/github-mention-highlighter
- - sindresorhus/notifier-for-github-chrome
  - sindresorhus/notifier-for-github
  - OctoLinker/OctoLinker
  - ProLoser/Github-Omnibox


### PR DESCRIPTION
It was renamed to a repo that was already here so just remove it.