### PR TITLE
browser extensions collection: add Mottie/GitHub-userscripts

### DIFF
--- a/collections/github-browser-extensions/index.md
+++ b/collections/github-browser-extensions/index.md
@@ -24,6 +24,7 @@ items:
  - marpo60/github-compare-tags
  - cheshire137/hubnav
  - ryanflorence/github-plusone-extension
+ - Mottie/GitHub-userscripts
 display_name: GitHub Browser Extensions
 created_by: leereilly
 ---


### PR DESCRIPTION
- [x] I followed the contributing guidelines: https://github.com/github/explore/blob/master/CONTRIBUTING.md

I am:
  - [x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [ ] Unaffiliated with the project (not self-promoting as e.g. a maintainer, creator, contractor or employee)

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288)
- [x] Content (and my changes are in `index.md`)

Mottie's GitHub-userscripts (https://github.com/Mottie/GitHub-userscripts) is a popular collection of GitHub userscripts