### PR TITLE
pr templates: standardize asterisk counts

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ I am:
   - [ ] Curating a new topic or collection
   - [ ] Unaffiliated with the project (not self-promoting as e.g. a maintainer, creator, contractor or employee)
 
-***********EDITING AN EXISTING TOPIC OR COLLECTION************
+************EDITING AN EXISTING TOPIC OR COLLECTION************
 
 I'm suggesting these edits to an existing topic or collection:
 - [ ] Image (and my file is `*.png`, square, dimensions 288x288)

--- a/.github/PULL_REQUEST_TEMPLATE/collection.md
+++ b/.github/PULL_REQUEST_TEMPLATE/collection.md
@@ -5,7 +5,7 @@ I am:
   - [ ] Curating a new collection
   - [ ] Unaffiliated with the project (not self-promoting as e.g. a maintainer, creator, contractor or employee)
 
-***********EDITING AN EXISTING COLLECTION************
+************EDITING AN EXISTING COLLECTION************
 
 I'm suggesting these edits to an existing collection:
 - [ ] Image (and my file is `*.png`, square, dimensions 288x288)

--- a/.github/PULL_REQUEST_TEMPLATE/topic.md
+++ b/.github/PULL_REQUEST_TEMPLATE/topic.md
@@ -5,7 +5,7 @@ I am:
   - [ ] Curating a new topic
   - [ ] Unaffiliated with the project (not self-promoting as e.g. a maintainer, creator, contractor or employee)
 
-***********EDITING AN EXISTING TOPIC************
+************EDITING AN EXISTING TOPIC************
 
 I'm suggesting these edits to an existing topic:
 - [ ] Image (and my file is `*.png`, square, dimensions 288x288)


### PR DESCRIPTION
- [x] I followed the contributing guidelines: https://github.com/github/explore/blob/master/CONTRIBUTING.md

When the PR templates use strings of asterisks, they don't use a standard number. That in itself wouldn't have caught my eye… but the Preview view of the PR message in a new PR did:

<kbd>
<img src="https://user-images.githubusercontent.com/3282350/39490343-96ffae32-4d56-11e8-9e33-5a8fd8540136.png">
</kbd>

When I sat down to delete that extra asterisk, I realized there was no standard number. With this PR, the extra asterisk is gone and the length of asterisk strings is standardized