### PR TITLE
Fix repo URL of The Lounge

### DIFF
--- a/topics/thelounge/index.md
+++ b/topics/thelounge/index.md
@@ -1,7 +1,7 @@
 ---
 aliases: thelounge-theme
 display_name: The Lounge
-github_url: https://github.com/thelounge/lounge
+github_url: https://github.com/thelounge/thelounge
 logo: thelounge.png
 related: irc, irc-client, chat, javascript
 released: February 12, 2016


### PR DESCRIPTION
- [x] I followed the contributing guidelines: https://github.com/github/explore/blob/master/CONTRIBUTING.md

I am:
  - [x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [ ] Unaffiliated with the project (not self-promoting as e.g. a maintainer, creator, contractor or employee)

***********EDITING AN EXISTING TOPIC OR COLLECTION************

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288)
- [x] Content (and my changes are in `index.md`)

Please explain why these changes are necessary:

The URL of the repository has changed recently. Even though the redirect is in effect, https://github.com/thelounge/thelounge is now the canonical location.

