### PR TITLE
Adding mlcourse_open to ML index.md

### DIFF
--- a/collections/machine-learning/index.md
+++ b/collections/machine-learning/index.md
@@ -30,6 +30,7 @@ items:
  - ujjwalkarn/Machine-Learning-Tutorials
  - ChristosChristofidis/awesome-deep-learning
  - fastai/courses
+ - Yorko/mlcourse_open
  - jtoy/awesome-tensorflow
  - nlintz/TensorFlow-Tutorials
  - pkmital/tensorflow_tutorials


### PR DESCRIPTION
Add the largest open (and free) machine learning course (articles, Jupyter notebooks, assignments, projects, tutorials, Kaggle Inclass competitions and active community OpenDataScience). Here is a publication on Medium https://medium.com/open-machine-learning-course

- \[x] I followed the contributing guidelines: https://github.com/github/explore/blob/master/CONTRIBUTING.md

I am:
  - \[x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [ ] Unaffiliated with the project (not self-promoting as e.g. a maintainer, creator, contractor or employee)

************EDITING AN EXISTING TOPIC OR COLLECTION************

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288)
- \[x] Content (and my changes are in `index.md`)

Please explain why these changes are necessary:
I'm proposing to include a very good free ML course. 

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**
