### PR TITLE
Add GDevelop game engine (javascript-game-engines)

### DIFF
--- a/collections/javascript-game-engines/index.md
+++ b/collections/javascript-game-engines/index.md
@@ -17,6 +17,7 @@ items:
  - GooTechnologies/goojs
  - shakiba/planck.js
  - Irrelon/ige
+ - 4ian/GD
 display_name: JavaScript Game Engines
 created_by: leereilly
 ---


### PR DESCRIPTION
- [x] I followed the contributing guidelines: https://github.com/github/explore/blob/master/CONTRIBUTING.md

I am:
  - [x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [ ] Unaffiliated with the project (not self-promoting as e.g. a maintainer, creator, contractor or employee)

************EDITING AN EXISTING TOPIC OR COLLECTION************

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288)
- [x] Content (and my changes are in `index.md`)

Please explain why these changes are necessary:

This adds GDevelop HTML5 game creator to the javascript-game-engines list. It's already on https://github.com/collections/game-engines (along with other engines like Pixi.js) so make sense to have in this more precise list too :)