### PR TITLE
Update name of moved repo

### DIFF
--- a/collections/github-browser-extensions/index.md
+++ b/collections/github-browser-extensions/index.md
@@ -2,7 +2,7 @@
 items:
  - buunguyen/octotree
  - mike-north/chrome-github-boxcutter
- - muan/dashboard
+ - muan/github-dashboard
  - muan/github-gmail
  - thieman/github-selfies
  - Yatser/prettypullrequests


### PR DESCRIPTION
The [muan/dashboard](https://github.com/muan/dashboard) repository has moved to [muan/github-dashboard](https://github.com/muan/github-dashboard).