### PR TITLE
Add an alias and some related topics to babel

### DIFF
--- a/topics/babel/index.md
+++ b/topics/babel/index.md
@@ -1,8 +1,10 @@
 ---
+aliases: babeljs
 created_by: Sebastian McKenzie, James Kyle, Henry Zhu, Logan Smyth, Daniel Tschinder
 display_name: Babel
 github_url: https://github.com/babel
 logo: babel.png
+related: babel-preset, babel-plugin, babel-es6
 released: September 28, 2014
 short_description: Babel is a compiler for writing next generation JavaScript, today.
 topic: babel


### PR DESCRIPTION
- [x] I followed the contributing guidelines: https://github.com/github/explore/blob/master/CONTRIBUTING.md
- [x] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).

### Which change are you proposing?

  - [x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection

---------------------------------------------------------------------

### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288)
- [x] Content (and my changes are in `index.md`)

I was just looking at a repository that had the babel-preset topic. When I clicked the topic, I noticed the babel-preset topic page has no information about what Babel is. Listing babel-preset as a related topic of babel will change this.

I did a search for "babel" and added the most used babel-related topics to the babel topic index.md to encourage further use and awareness. https://github.com/search?q=babel&type=Topics
