### PR TITLE
collections/software-development-tools: redirect better_errors.

### DIFF
--- a/collections/software-development-tools/index.md
+++ b/collections/software-development-tools/index.md
@@ -4,7 +4,7 @@ items:
  - pengwynn/flint
  - mislav/rfc
  - peek/peek
- - charliesome/better_errors
+ - BetterErrors/better_errors
  - jshint/jshint
  - validator/validator
  - travis-ci/travis-ci


### PR DESCRIPTION
It now lives in its own org.