### PR TITLE
collections/social-impact: redirect alex.

### DIFF
--- a/collections/social-impact/index.md
+++ b/collections/social-impact/index.md
@@ -2,7 +2,7 @@
 items:
  - GliaX/Stethoscope
  - HospitalRun/hospitalrun-frontend
- - wooorm/alex
+ - get-alex/alex
  - coralproject/talk
  - hotosm/tasking-manager
  - OptiKey/OptiKey


### PR DESCRIPTION
This has moved to a get-alex organisation.