### PR TITLE
Revert "Bump rake from 12.3.1 to 12.3.2"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
       ast (~> 2.4.0)
     powerpack (0.1.2)
     rainbow (3.0.0)
-    rake (12.3.2)
+    rake (12.3.1)
     rubocop (0.61.1)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)


### PR DESCRIPTION
Reverts github/explore#485