### PR TITLE
Add hybrids library, lexicographical order

### DIFF
--- a/collections/front-end-javascript-frameworks/index.md
+++ b/collections/front-end-javascript-frameworks/index.md
@@ -1,25 +1,25 @@
 ---
 items:
- - marko-js/marko
- - mithriljs/mithril.js
  - angular/angular
- - emberjs/ember.js
- - knockout/knockout
- - tastejs/todomvc
- - spine/spine
- - vuejs/vue
- - Polymer/polymer
- - facebook/react
- - matreshkajs/matreshka
  - aurelia/framework
- - optimizely/nuclear-js
- - jashkenas/backbone
- - dojo/dojo
- - jorgebucaran/hyperapp
- - riot/riot
  - daemonite/material
+ - dojo/dojo
+ - emberjs/ember.js
+ - facebook/react
+ - hybridsjs/hybrids
+ - jashkenas/backbone
+ - jorgebucaran/hyperapp
+ - knockout/knockout
+ - marko-js/marko
+ - matreshkajs/matreshka
+ - mithriljs/mithril.js
+ - optimizely/nuclear-js
  - polymer/lit-element
- - aurelia/aurelia
+ - Polymer/polymer
+ - riot/riot
+ - spine/spine
+ - tastejs/todomvc
+ - vuejs/vue
 display_name: Front-end JavaScript frameworks
 created_by: jonrohan
 ---


### PR DESCRIPTION
The list should be sorted and I think the obvious solution is a lexicographical order. The commit changes:

* Added hybrids library
* Sorted list
* Removed duplicate - `aurelia/aurelia` - it is not a current version of the library and it is already on the list with `aurelia/framework`

### Thank you for contributing! Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: https://github.com/github/explore/blob/master/CONTRIBUTING.md
- [ ] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).

### Which change are you proposing?

  - [x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection

---------------------------------------------------------------------

<!-- ⚠️ Please select either this section... ⚠️ -->
### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288)
- [x] Content (and my changes are in `index.md`)

> Please replace this line with an explanation of why you think these changes should be made.

<!-- ⚠️ ... or this section ⚠️ -->
### Curating a new topic or collection

- [ ] I've formatted my changes as a new folder directory, named for the topic or collection as it appears in the URL on GitHub (e.g. `https://github.com/topics/[NAME]` or `https://github.com/collections/[NAME]`)
- [ ] My folder contains a `*.png` image (if applicable) and `index.md`
- [x] All required fields in my `index.md` conform to the Style Guide and API docs: https://github.com/github/explore/tree/master/docs

> Please replace this line with an explanation of why you think this topic or collection should be curated.

---------------------------------------------------------------------

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**
