### PR TITLE
Update Rust URL

### DIFF
--- a/topics/rust/index.md
+++ b/topics/rust/index.md
@@ -8,7 +8,7 @@ related: language, c-plus-plus
 released: '2010'
 short_description: Rust is a systems programming language created by Mozilla.
 topic: rust
-url: https://www.rust-lang.org/en-US/
+url: https://www.rust-lang.org/
 wikipedia_url: https://en.wikipedia.org/wiki/Rust_(programming_language)
 ---
 Rust is a systems programming language created by Mozilla. It is similar to C++, but is designed for improved memory safety without sacrificing performance.


### PR DESCRIPTION
Rust project [updated its website](https://blog.rust-lang.org/2018/11/29/a-new-look-for-rust-lang-org.html) and https://www.rust-lang.org/en-US/ is currently 404. Update to https://www.rust-lang.org/.