### PR TITLE
Remove loli language

### DIFF
--- a/collections/programming-languages/index.md
+++ b/collections/programming-languages/index.md
@@ -43,7 +43,6 @@ items:
 - lucee/Lucee
 - eclipse/golo-lang
 - gosu-lang/gosu-lang
-- loli-foundation/loli
 display_name: Programming languages
 created_by: leereilly
 ---


### PR DESCRIPTION
Looks like this repo is no longer available. I couldn't find where it
moved to since the entire https://github.com/loli-foundation
organization is gone, so deleting.