### PR TITLE
Rename moved repositories

### DIFF
--- a/collections/choosing-projects/index.md
+++ b/collections/choosing-projects/index.md
@@ -3,7 +3,7 @@ items:
  - rust-lang/rust
  - HospitalRun/hospitalrun-frontend
  - hoodiehq/hoodie
- - pybee/batavia
+ - beeware/batavia
  - Homebrew/brew
  - https://www.youtube.com/embed/dSl_qnWO104
 display_name: How to choose (and contribute to) your first open source project

--- a/collections/github-browser-extensions/index.md
+++ b/collections/github-browser-extensions/index.md
@@ -25,7 +25,7 @@ items:
  - cheshire137/hubnav
  - ryanflorence/github-plusone-extension
  - Mottie/GitHub-userscripts
- - rgehan/octolenses-browser-extension
+ - rgehan/octolenses
  - xxhomey19/github-file-icon
 display_name: GitHub Browser Extensions
 created_by: leereilly


### PR DESCRIPTION
Builds are broken 😒: 

>   1) Failure:
collections::choosing-projects collection#test_0007_fails if a user, organization, or repository has been renamed [/home/travis/build/github/explore/test/collections_test.rb:90]:
Expected ["choosing-projects: pybee/batavia has been renamed to beeware/batavia"] to be empty.
>   2) Failure:
collections::github-browser-extensions collection#test_0007_fails if a user, organization, or repository has been renamed [/home/travis/build/github/explore/test/collections_test.rb:90]:
Expected ["github-browser-extensions: rgehan/octolenses-browser-extension has been renamed to rgehan/octolenses"] to be empty.

https://travis-ci.org/github/explore/builds/514139240?utm_source=github_status&utm_medium=notification