### PR TITLE
Adding Svelte in front-end frameworks list

### DIFF
--- a/collections/front-end-javascript-frameworks/index.md
+++ b/collections/front-end-javascript-frameworks/index.md
@@ -1,6 +1,5 @@
 ---
 items:
- - sveltejs/svelte
  - marko-js/marko
  - mithriljs/mithril.js
  - angular/angular
@@ -21,6 +20,7 @@ items:
  - daemonite/material
  - polymer/lit-element
  - aurelia/aurelia
+ - sveltejs/svelte
 display_name: Front-end JavaScript frameworks
 created_by: jonrohan
 ---

--- a/collections/front-end-javascript-frameworks/index.md
+++ b/collections/front-end-javascript-frameworks/index.md
@@ -1,5 +1,6 @@
 ---
 items:
+ - sveltejs/svelte
  - marko-js/marko
  - mithriljs/mithril.js
  - angular/angular


### PR DESCRIPTION
### Thank you for contributing! Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: https://github.com/github/explore/blob/master/CONTRIBUTING.md
- [x] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).

### Which change are you proposing?

  - [x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection

---------------------------------------------------------------------

<!-- ⚠️ Please select either this section... ⚠️ -->
### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288)
- [x] Content (and my changes are in `index.md`)

> Svelte has just released its v3 which presents revolutionary concepts in the front-end component healm. I'm a dev who uses it since v2 and I think it's time to add Svelte to this list since it gathered quite a popularity over the last 2 years.

---------------------------------------------------------------------

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**
