### PR TITLE
Reword Rails's relationship to Ruby for accuracy

### DIFF
--- a/topics/ruby/index.md
+++ b/topics/ruby/index.md
@@ -11,4 +11,4 @@ topic: ruby
 url: https://www.ruby-lang.org/en/
 wikipedia_url: https://en.wikipedia.org/wiki/Ruby_(programming_language)
 ---
-Ruby was developed by Yukihiro "Matz" Matsumoto in 1995 with the intent of having an easily readable programming language. It is integrated with the Rails framework to create dynamic web-applications. Ruby's syntax is similar to that of Perl and Python.
+Ruby was developed by Yukihiro "Matz" Matsumoto in 1995 with the intent of having an easily readable programming language. It is used by the Rails framework to create dynamic web-applications. Ruby's syntax is similar to that of Perl and Python.


### PR DESCRIPTION
### Thank you for contributing! Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: https://github.com/github/explore/blob/master/CONTRIBUTING.md
- [x] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).

### Which change are you proposing?

  - [x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection

---------------------------------------------------------------------

<!-- ⚠️ Please select either this section... ⚠️ -->
### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288)
- [x] Content (and my changes are in `index.md`)

To say that Ruby is "integrated with" Ruby is inaccurate. The relationship between Rails and Ruby is one-way: Rails is written in Ruby and enables one to write programs in Ruby. Ruby functions completely independently of Rails.

While creating applications with Rails is a very popular use of Ruby (perhaps one of the _most_ popular), this popularity can cause confusion for new developers. It can be unclear if methods, data structures, etc. are part of the Rails framework or part of the Ruby language itself. Hopefully this change clarifies this a bit better.

I welcome further changes to my wording to make this message sound even more natural.