### PR TITLE
Start using `rubocop-performance` to fix deprecation warning

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+require: rubocop-performance
+
 AllCops:
   TargetRubyVersion: 2.4
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,6 @@ group :test do
   gem "minitest"
   gem "rake"
   gem "rubocop"
+  gem "rubocop-performance"
   gem "safe_yaml"
 end


### PR DESCRIPTION
> Performance Cops will be removed from RuboCop 0.68. Use rubocop-performance gem instead.