### PR TITLE
Update baidu, time, and deeplearning4

### DIFF
--- a/collections/ai-model-zoos/index.md
+++ b/collections/ai-model-zoos/index.md
@@ -5,7 +5,7 @@ items:
  - BVLC/caffe
  - caffe2/models
  - apache/incubator-mxnet
- - deeplearning4j/deeplearning4j
+ - eclipse/deeplearning4j
  - sdhnshu/pytorch-model-zoo
  - Lasagne/Recipes
  - albertomontesg/keras-model-zoo

--- a/collections/open-journalism/index.md
+++ b/collections/open-journalism/index.md
@@ -8,7 +8,7 @@ items:
  - propublica/guides
  - censusreporter/censusreporter
  - nprapps/app-template
- - TimeMagazine/babynames
+ - TimeMagazineLabs/babynames
  - guardian/frontend
  - dukechronicle/chronline
  - BloombergMedia/whatiscode

--- a/collections/open-source-organizations/index.md
+++ b/collections/open-source-organizations/index.md
@@ -20,7 +20,6 @@ items:
  - eleme/eleme.github.io
  - didi/didi.github.io
  - alibaba/alibaba.github.com
- - baidu/baidu.github.io
 display_name: Open source organizations
 created_by: benbalter
 image: open-source-organizations.png


### PR DESCRIPTION
Fixing a few repos that have moved or been removed.

```
 1) Failure:
collections::open-source-organizations collection#test_0005_fails if a repository does not exist or is private [/home/travis/build/github/explore/test/collections_test.rb:56]:
Expected ["open-source-organizations: baidu/baidu.github.io does not exist or is private"] to be empty.
  2) Failure:
collections::open-journalism collection#test_0007_fails if a user, organization, or repository has been renamed [/home/travis/build/github/explore/test/collections_test.rb:90]:
Expected ["open-journalism: TimeMagazine/babynames has been renamed to TimeMagazineLabs/babynames"] to be empty.
  3) Failure:
collections::ai-model-zoos collection#test_0007_fails if a user, organization, or repository has been renamed [/home/travis/build/github/explore/test/collections_test.rb:90]:
Expected ["ai-model-zoos: deeplearning4j/deeplearning4j has been renamed to eclipse/deeplearning4j"] to be empty.
```

https://travis-ci.org/github/explore/builds/541595489