### PR TITLE
Use new repo syntax

### DIFF
--- a/collections/pixel-art-tools/index.md
+++ b/collections/pixel-art-tools/index.md
@@ -1,14 +1,14 @@
 ---
 items:
- - https://github.com/aseprite/aseprite/
- - https://github.com/piskelapp/piskel/
- - https://github.com/jvalen/pixel-art-react/
- - https://github.com/maierfelix/poxi/
- - https://github.com/gmattie/Data-Pixels/
- - https://github.com/vsmode/pixel8
- - https://github.com/jennschiffer/make8bitart
- - https://github.com/kitao/pyxel
- - https://github.com/jackschaedler/goya
+ - aseprite/aseprite/
+ - piskelapp/piskel/
+ - jvalen/pixel-art-react/
+ - maierfelix/poxi/
+ - gmattie/Data-Pixels/
+ - vsmode/pixel8
+ - jennschiffer/make8bitart
+ - kitao/pyxel
+ - jackschaedler/goya
 display_name: Pixel Art Tools
 created_by: leereilly
 image: pixel-art-tools.png


### PR DESCRIPTION
This commit:
  - Removes the https://github.com/ from all of the items

Why?
  - This is no longer needed