### PR TITLE
Drop FascinatedBox/lily because it's no longer being developed on GitHub

### DIFF
--- a/collections/programming-languages/index.md
+++ b/collections/programming-languages/index.md
@@ -38,7 +38,6 @@ items:
 - terralang/terra
 - dotnet/fsharp
 - skiplang/skip
-- FascinatedBox/lily
 - rakudo/rakudo
 - chapel-lang/chapel
 - lucee/Lucee


### PR DESCRIPTION

### Thank you for contributing! Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: https://github.com/github/explore/blob/master/CONTRIBUTING.md
- [x] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).

### Which change are you proposing?

  - [x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection

---------------------------------------------------------------------

### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288)
- [x] Content (and my changes are in `index.md`)

I'm proposing dropping `FascinatedBox/lily` from the GitHub programming-languages collections list because it seems that the development moved to GitLab according to [their page](https://github.com/FascinatedBox/lily).
