### PR TITLE
Add emacs mirror

### DIFF
--- a/collections/text-editors/index.md
+++ b/collections/text-editors/index.md
@@ -10,6 +10,7 @@ items:
  - Komodo/KomodoEdit
  - leo-editor/leo-editor
  - syl20bnr/spacemacs
+ - emacs-mirror/emacs
  - SpaceVim/SpaceVim
  - alm-tools/alm
  - atom/atom


### PR DESCRIPTION
While spacemacs is already on the list, it's a shame that not even the Emacs mirror is listed. This edit encapsulates the fix for this.

### Thank you for contributing! Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: https://github.com/github/explore/blob/master/CONTRIBUTING.md
- [x] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).

### Which change are you proposing?

  - [x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection

---------------------------------------------------------------------

<!-- ⚠️ Please select either this section... ⚠️ -->
### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288)
- [x] Content (and my changes are in `index.md`)

> Please replace this line with an explanation of why you think these changes should be made.

---------------------------------------------------------------------

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**
