### PR TITLE
Added Lospec's web-based pixel editor

### DIFF
--- a/collections/pixel-art-tools/index.md
+++ b/collections/pixel-art-tools/index.md
@@ -2,6 +2,7 @@
 items:
  - aseprite/aseprite/
  - piskelapp/piskel/
+ - lospec/pixel-editor
  - jvalen/pixel-art-react/
  - maierfelix/poxi/
  - gmattie/Data-Pixels/


### PR DESCRIPTION
### Thank you for contributing! Please confirm this pull request meets the following requirements:

- [X] I followed the contributing guidelines: https://github.com/github/explore/blob/master/CONTRIBUTING.md
- [X] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).

### Which change are you proposing?

  - [X] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection

---------------------------------------------------------------------

<!-- ⚠️ Please select either this section... ⚠️ -->
### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288)
- [X] Content (and my changes are in `index.md`)

Lospec is a pretty popular website in the pixel art community (it's mostly used to find and share palettes) and many people who browse the website also use its Pixel Editor. It is a nice and very intuitive tool that is easy enough for beginners to start using it and functional enough for veterans to find it useful.