### PR TITLE
Add Preact to the list of frontend js frameworks

### DIFF
--- a/collections/front-end-javascript-frameworks/index.md
+++ b/collections/front-end-javascript-frameworks/index.md
@@ -22,6 +22,7 @@ items:
  - aurelia/aurelia
  - sveltejs/svelte
  - neomjs/neo
+ - preactjs/preact
 display_name: Front-end JavaScript frameworks
 created_by: jonrohan
 ---


### PR DESCRIPTION
### Thank you for contributing! Please confirm this pull request meets the following requirements:

- [X] I followed the contributing guidelines: https://github.com/github/explore/blob/master/CONTRIBUTING.md
- [X] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).

### Which change are you proposing?

  - [X] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection

---------------------------------------------------------------------

### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288)
- [X] Content (and my changes are in `index.md`)

This change is to add Preact as a helpful resource in creating single page applications. It's a pretty popular framework at the moment, both because it shares an API with React, and because of its focus on having a minimal bundle size. Looking at the existing list it definitely fits in, and I would guess is more popular/more often used than several items already accepted.

---------------------------------------------------------------------
