### PR TITLE
Add Hakyll to static site generators

### DIFF
--- a/collections/static-site-generators/index.md
+++ b/collections/static-site-generators/index.md
@@ -18,6 +18,7 @@ items:
  - mkdocs/mkdocs
  - sintaxi/harp
  - netlify/netlify-cms
+ - jaspervdj/hakyll
 display_name: Static Site Generators
 created_by: jakejarvis
 ---


### PR DESCRIPTION
### Thank you for contributing! Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: https://github.com/github/explore/blob/master/CONTRIBUTING.md
- [x] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).

### Which change are you proposing?

  - [x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [ ] Something that does not neatly fit into the binary options above

---------------------------------------------------------------------

### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288)
- [x] Content (and my changes are in `index.md`)

I think Hakyll is a popular enough static site generator that it would fit nicely into this list. It's very pleasant to work with, especially if you're already working in the Haskell community :). 