### PR TITLE
Add jnunemaker/flipper to Projects that power GitHub

### DIFF
--- a/collections/projects-that-power-github/index.md
+++ b/collections/projects-that-power-github/index.md
@@ -34,6 +34,7 @@ items:
  - gjtorikian/html-proofer
  - babel/babel
  - stylelint/stylelint
+ - jnunemaker/flipper
 display_name: Projects that power GitHub
 created_by: leereilly
 image: projects-that-power-github.png


### PR DESCRIPTION
### Thank you for contributing! Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: https://github.com/github/explore/blob/master/CONTRIBUTING.md
- [x] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).

### Which change are you proposing?

  - [x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [ ] Something that does not neatly fit into the binary options above

---------------------------------------------------------------------

<!-- ⚠️ Please select either this section... ⚠️ -->
### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288)
- [x] Content (and my changes are in `index.md`)

I found that GitHub is using **jnunemaker/flipper** for feature flagging service mentioned in https://dev.to/mscccc/comment/k43l

---------------------------------------------------------------------

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

/cc @jnunemaker (owner of the project) @mscoutermarsh (found in Mike Coutermarsh's blog)