### PR TITLE
Add "c++" as an alias to CPP

### DIFF
--- a/topics/cpp/index.md
+++ b/topics/cpp/index.md
@@ -1,5 +1,5 @@
 ---
-aliases: cplusplus, c-plus-plus, cpps, cpp98, cpp03, cpp11, cpp14, cpp17, cpp20, cpp0x, cpp1y, cpp1z, cpp2a, cplusplus-11
+aliases: cplusplus, c-plus-plus, cpps, cpp98, cpp03, cpp11, cpp14, cpp17, cpp20, cpp0x, cpp1y, cpp1z, cpp2a, cplusplus-11, c++
 created_by: Bjarne Stroustrup
 display_name: C++
 logo: cpp.png

--- a/topics/cpp/index.md
+++ b/topics/cpp/index.md
@@ -1,5 +1,5 @@
 ---
-aliases: cplusplus, c-plus-plus, cpps, cpp98, cpp03, cpp11, cpp14, cpp17, cpp20, cpp0x, cpp1y, cpp1z, cpp2a, cplusplus-11, c2B%2B
+aliases: cplusplus, c-plus-plus, cpps, cpp98, cpp03, cpp11, cpp14, cpp17, cpp20, cpp0x, cpp1y, cpp1z, cpp2a, cplusplus-11, c%2B%2B
 created_by: Bjarne Stroustrup
 display_name: C++
 logo: cpp.png

--- a/topics/cpp/index.md
+++ b/topics/cpp/index.md
@@ -1,5 +1,5 @@
 ---
-aliases: cplusplus, c-plus-plus, cpps, cpp98, cpp03, cpp11, cpp14, cpp17, cpp20, cpp0x, cpp1y, cpp1z, cpp2a, cplusplus-11, c2B%2B=c++
+aliases: cplusplus, c-plus-plus, cpps, cpp98, cpp03, cpp11, cpp14, cpp17, cpp20, cpp0x, cpp1y, cpp1z, cpp2a, cplusplus-11, c2B%2B
 created_by: Bjarne Stroustrup
 display_name: C++
 logo: cpp.png

--- a/topics/cpp/index.md
+++ b/topics/cpp/index.md
@@ -1,5 +1,5 @@
 ---
-aliases: cplusplus, c-plus-plus, cpps, cpp98, cpp03, cpp11, cpp14, cpp17, cpp20, cpp0x, cpp1y, cpp1z, cpp2a, cplusplus-11, c++
+aliases: cplusplus, c-plus-plus, cpps, cpp98, cpp03, cpp11, cpp14, cpp17, cpp20, cpp0x, cpp1y, cpp1z, cpp2a, cplusplus-11, c%2B%2B
 created_by: Bjarne Stroustrup
 display_name: C++
 logo: cpp.png

--- a/topics/cpp/index.md
+++ b/topics/cpp/index.md
@@ -1,5 +1,5 @@
 ---
-aliases: cplusplus, c-plus-plus, cpps, cpp98, cpp03, cpp11, cpp14, cpp17, cpp20, cpp0x, cpp1y, cpp1z, cpp2a, cplusplus-11, c%2B%2B
+aliases: cplusplus, c-plus-plus, cpps, cpp98, cpp03, cpp11, cpp14, cpp17, cpp20, cpp0x, cpp1y, cpp1z, cpp2a, cplusplus-11, c2B%2B=c++
 created_by: Bjarne Stroustrup
 display_name: C++
 logo: cpp.png


### PR DESCRIPTION
### Thank you for contributing! Please confirm this pull request meets the following requirements:

- [-] I followed the contributing guidelines: https://github.com/github/explore/blob/master/CONTRIBUTING.md
- [-] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).

### Which change are you proposing?

  - [-] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [ ] Something that does not neatly fit into the binary options above

---------------------------------------------------------------------

<!-- ⚠️ Please select either this section... ⚠️ -->
### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288)
- [-] Content (and my changes are in `index.md`)

> Many users may use "c++" instead of "cpp" because it is the name of the language.
