### PR TITLE
github-browser-extensions: Add github-show-avatars

### DIFF
--- a/collections/github-browser-extensions/index.md
+++ b/collections/github-browser-extensions/index.md
@@ -35,6 +35,7 @@ items:
  - n1ck/gifs-for-github
  - EnixCoda/Gitako
  - vladgolubev/quickreview-for-github
+ - matthizou/github-show-avatars
 display_name: GitHub Browser Extensions
 created_by: leereilly
 ---


### PR DESCRIPTION
### Thank you for contributing! Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: https://github.com/github/explore/blob/master/CONTRIBUTING.md
- [x] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).

### Which change are you proposing?

  - [x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [ ] Something that does not neatly fit into the binary options above

---------------------------------------------------------------------

<!-- ⚠️ Please select either this section... ⚠️ -->
### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288)
- [x] Content (and my changes are in `index.md`)

> Simple and useful extension that adds more visibility to the PR list by adding the avatars of the creators
