### PR TITLE
Add home assistant alias without dash

### DIFF
--- a/topics/home-assistant/index.md
+++ b/topics/home-assistant/index.md
@@ -4,7 +4,7 @@ display_name: Home Assistant
 topic: home-assistant
 github_url: https://github.com/home-assistant
 logo: home-assistant.png
-related: homeassistant, home-assistant-config, home-assistant-configuration, hassio
+related: home-assistant-config, home-assistant-configuration, hassio
 short_description: Open source home automation that puts local control and privacy first.
 url: https://www.home-assistant.io
 ---

--- a/topics/home-assistant/index.md
+++ b/topics/home-assistant/index.md
@@ -1,4 +1,5 @@
 ---
+aliases: homeassistant
 display_name: Home Assistant
 topic: home-assistant
 github_url: https://github.com/home-assistant


### PR DESCRIPTION
### Thank you for contributing! Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: https://github.com/github/explore/blob/master/CONTRIBUTING.md
- [x] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).

### Which change are you proposing?

  - [x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [ ] Something that does not neatly fit into the binary options above

---------------------------------------------------------------------

### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288)
- [x] Content (and my changes are in `index.md`)

> A lot of repos use `homeassistant`. This adds an alias for `home-assistant` as `homeassistant`.

---------------------------------------------------------------------

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**
