### PR TITLE
Include Stripe GH Page to OSS Orgs collection

### DIFF
--- a/collections/open-source-organizations/index.md
+++ b/collections/open-source-organizations/index.md
@@ -24,6 +24,7 @@ items:
  - proyecto26/proyecto26.github.io
  - mozilla/mozilla.github.io
  - zalando/zalando.github.io
+ - stripe/stripe.github.io
 display_name: Open source organizations
 created_by: benbalter
 image: open-source-organizations.png


### PR DESCRIPTION
### Thank you for contributing! Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: https://github.com/github/explore/blob/master/CONTRIBUTING.md
- [x] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).

### Which change are you proposing?

  - [x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [ ] Something that does not neatly fit into the binary options above

---------------------------------------------------------------------

### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288)
- [x] Content (and my changes are in `index.md`)

This PR adds Stripe GH page, `stripe/stripe.github.io`, to the collection named **Open Source Organizations**. I consider it was missing on the organizations listed there, and they have contributed to OSS for a while now.

---------------------------------------------------------------------

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**
