### PR TITLE
removed archived repository from "Choosing Projects" page

### DIFF
--- a/collections/choosing-projects/index.md
+++ b/collections/choosing-projects/index.md
@@ -3,7 +3,6 @@ items:
  - rust-lang/rust
  - HospitalRun/hospitalrun-frontend
  - hoodiehq/hoodie
- - beeware/batavia
  - Homebrew/brew
  - https://www.youtube.com/embed/dSl_qnWO104
  - public-apis/public-apis


### PR DESCRIPTION
### Thank you for contributing! Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: https://github.com/github/explore/blob/master/CONTRIBUTING.md
- [x] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).

### Which change are you proposing?

  - [x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [ ] Something that does not neatly fit into the binary options above

---------------------------------------------------------------------

<!-- ⚠️ Please select either this section... ⚠️ -->
### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288)
- [x] Content (and my changes are in `index.md`)

> I'm suggesting removing ```beeware/batavia``` from the "How to choose (and contribute to) your first open source project" page because it has been archived and is now read-only.

---------------------------------------------------------------------

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**
