### PR TITLE
use correct URL for React Native website

### DIFF
--- a/topics/react-native/index.md
+++ b/topics/react-native/index.md
@@ -9,6 +9,6 @@ released: January 2015
 short_description: React Native is a JavaScript mobile framework developed by Facebook.
 topic: react-native
 url: https://reactnative.dev/
-wikipedia_url: https://en.wikipedia.org/wiki/React_(JavaScript_library)#React_Native
+wikipedia_url: https://en.wikipedia.org/wiki/React_Native
 ---
 React Native is a JavaScript mobile framework developed by Facebook. It allows developers to build Android and iOS mobile apps using JavaScript and reuse code across web and mobile applications.

--- a/topics/react-native/index.md
+++ b/topics/react-native/index.md
@@ -8,7 +8,7 @@ related: reactjs
 released: January 2015
 short_description: React Native is a JavaScript mobile framework developed by Facebook.
 topic: react-native
-url: http://reactnative.com/
+url: https://reactnative.dev/
 wikipedia_url: https://en.wikipedia.org/wiki/React_(JavaScript_library)#React_Native
 ---
 React Native is a JavaScript mobile framework developed by Facebook. It allows developers to build Android and iOS mobile apps using JavaScript and reuse code across web and mobile applications.


### PR DESCRIPTION
### Thank you for contributing! Please confirm this pull request meets the following requirements:

- [X] I followed the contributing guidelines: https://github.com/github/explore/blob/master/CONTRIBUTING.md
- [ ] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).

### Which change are you proposing?

  - [X] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [ ] Something that does not neatly fit into the binary options above

---

<!-- ⚠️ Please select either this section... ⚠️ -->
### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288)
- [X] Content (and my changes are in `index.md`)

---

Currently the URL used in the React Native topic leads to unsecured and unofficial website.

This PR updates the URL to point to the official React Native website located at:
* https://reactnative.dev/

And the source code is available at:
* https://github.com/facebook/react-native-website

I have also updated the Wikipedia link, since React Native have it's own page for a some time:
* https://en.wikipedia.org/wiki/React_Native

---

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**
