### PR TITLE
add hascal programming language

### DIFF
--- a/collections/programming-languages/index.md
+++ b/collections/programming-languages/index.md
@@ -54,6 +54,7 @@ items:
 - ring-lang/ring
 - SenegalLang/Senegal
 - yegor256/eo
+- hascal/hascal
 display_name: Programming languages
 created_by: leereilly
 ---


### PR DESCRIPTION
Hi.I added link of hascal programming language repo in end of [index.md](https://github.com/github/explore/blob/master/collections/programming-languages/index.md ) file in programming languages collection.
