### PR TITLE
Remove Greenstand/Development-Overview because it's private

### DIFF
--- a/collections/social-impact/index.md
+++ b/collections/social-impact/index.md
@@ -17,7 +17,6 @@ items:
  - raksha-life/rescuekerala
  - Data4Democracy/ethics-resources
  - civicdata/civicdata.github.io
- - Greenstand/Development-Overview
  - yunity/karrot-frontend
 display_name: Social Impact
 created_by: bescalante

--- a/collections/software-defined-radio/index.md
+++ b/collections/software-defined-radio/index.md
@@ -7,7 +7,7 @@ items:
  - miek/inspectrum
  - kpreid/shinysdr
  - RangeNetworks/openbts
- - srsLTE/srsUE
+ - srsRAN/srsRAN
  - xmikos/qspectrumanalyzer
  - cjcliffe/CubicSDR
  - jopohl/urh


### PR DESCRIPTION
### Thank you for contributing! Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: https://github.com/github/explore/blob/master/CONTRIBUTING.md
- [ ] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).

### Which change are you proposing?

  - [x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [ ] Something that does not neatly fit into the binary options above


This combined with https://github.com/github/explore/pull/2322 should get CI green again