### PR TITLE
Remove stepperUnipolar

### DIFF
--- a/collections/made-in-cuba/index.md
+++ b/collections/made-in-cuba/index.md
@@ -11,7 +11,6 @@ items:
  - jadolg/rocketchat_API
  - pavelmc/FT857d
  - pavelmc/Si5351mcu
- - stepperUnipolar
  - pavelmc/Yatuli
  - pavelmc/BMux
  - pavelmc/arduino-arcs


### PR DESCRIPTION
Causing to CI to fail because https://api.github.com/users/stepperUnipolar returns a 403 - possibly a user rename?