### PR TITLE
Add Lite XL editor

### DIFF
--- a/collections/text-editors/index.md
+++ b/collections/text-editors/index.md
@@ -25,6 +25,7 @@ items:
  - JetBrains/intellij-community
  - emacs-mirror/emacs
  - rxi/lite
+ - franko/lite-xl
  - howl-editor/howl
  - notepad-plus-plus/notepad-plus-plus
  - XhmikosR/notepad2-mod


### PR DESCRIPTION
### Thank you for contributing! Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: https://github.com/github/explore/blob/master/CONTRIBUTING.md
- [x] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).

### Which change are you proposing?

  - [x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [ ] Something that does not neatly fit into the binary options above

---------------------------------------------------------------------

### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288)
- [x] Content (and my changes are in `index.md`)

Lite XL is a text editor which improves on top of Lite, an editor already in this collection. I suggest adding it alongside Lite.
