### PR TITLE
Update index.md for Game Engines Collection

### DIFF
--- a/collections/game-engines/index.md
+++ b/collections/game-engines/index.md
@@ -2,8 +2,8 @@
 items:
  - godotengine/godot
  - turbulenz/turbulenz_engine
- - GarageGames/Torque3D
- - GarageGames/Torque2D
+ - TorqueGameEngines/Torque3D
+ - TorqueGameEngines/Torque2D
  - spring/spring
  - cocos2d/cocos2d-x
  - Gamua/Starling-Framework


### PR DESCRIPTION
Updated GarageGames game engine listings to their new repos, the current repos listed are no longer receiving updates.

### Thank you for contributing! Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: https://github.com/github/explore/blob/master/CONTRIBUTING.md
- [x] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).

### Which change are you proposing?

  - [x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [ ] Something that does not neatly fit into the binary options above

---------------------------------------------------------------------

<!-- ⚠️ Please select either this section... ⚠️ -->
### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288)
- [x] Content (and my changes are in `index.md`)

GarageGames have moved their game engines to new repos, the current game engine collection on the explore page still displays the old repos however. In this pull request, the index.md has been edited to replace the old GarageGame engine repos with their new and updated versions. The README in the Old Torque2D Engine states that all Torque Engines are moving repos and organizations.(https://github.com/GarageGames/Torque2D/blob/master/README.md), the wiki for Torque2D states this as well. However this is not mentioned in the Old Torque3D repository.