### PR TITLE
Fix grammar in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ There are a few ways you can contribute:
 - Improving an existing topic or collection
 - Curating a new topic or collection
 
-As you write content, check out the [Style Guide](./docs/styleguide.md) to learn what each field means, and how they should be formatted. Following the style guide will increase the chances of your contribution being accepted.
+As you write content, check out the [Style Guide](./docs/styleguide.md) to learn what each field means, and how it should be formatted. Following the style guide will increase the chances of your contribution being accepted.
 
 Note: Updates won't immediately appear once we've merged your PR. We pull in these changes regularly to GitHub.
 


### PR DESCRIPTION
### Thank you for contributing! Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: https://github.com/github/explore/blob/master/CONTRIBUTING.md
- [x] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).

### Which change are you proposing?

  - [ ] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [x] Something that does not neatly fit into the binary options above

---------------------------------------------------------------------

### Something that does not neatly fit into the binary options above

- [x] My suggested edits are not about an existing topic or collection, or at least not a single one
- [x] My suggested edits are not about curating a new topic or collection, or at least not a single one
- [ ] My suggested edits conform to the Style Guide and API docs: https://github.com/github/explore/tree/master/docs

> "As you write content, check out the [Style Guide](./docs/styleguide.md) to learn what each field means, and how they should be formatted."
> You cannot use "they" in this context after "each"
> You *could* use either:
> "As you write content, check out the [Style Guide](./docs/styleguide.md) to learn what each field means, and how it should be formatted." (My suggestion)
> or
> "As you write content, check out the [Style Guide](./docs/styleguide.md) to learn how they should be formatted, and what each field means."
