### PR TITLE
Remove the /en/ to allow redirects in Ruby's topic

### DIFF
--- a/topics/ruby/index.md
+++ b/topics/ruby/index.md
@@ -8,7 +8,7 @@ released: December 21, 1995
 short_description: Ruby is a scripting language designed for simplified object-oriented
   programming.
 topic: ruby
-url: https://www.ruby-lang.org/en/
+url: https://www.ruby-lang.org/
 wikipedia_url: https://en.wikipedia.org/wiki/Ruby_(programming_language)
 ---
 Ruby was developed by Yukihiro "Matz" Matsumoto in 1995 with the intent of having an easily readable programming language. It is used by the Rails framework to create dynamic web-applications. Ruby's syntax is similar to that of Perl and Python.


### PR DESCRIPTION
### Thank you for contributing! Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: https://github.com/github/explore/blob/master/CONTRIBUTING.md
- [x] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).

### Which change are you proposing?

  - [x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [ ] Something that does not neatly fit into the binary options above

---------------------------------------------------------------------

### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288)
- [x] Content (and my changes are in `index.md`)

> I removed the /en/ at the end of the URL to allow people from other nationalities to be redirected to a page suitable to them.