### PR TITLE
Topics: Remove duplicate aliases and related topics

### DIFF
--- a/test/topics_test_helper.rb
+++ b/test/topics_test_helper.rb
@@ -62,7 +62,7 @@ def related_topics_for(topic)
   return [] unless metadata
   return [] unless metadata["related"]
 
-  metadata["related"].split(",")
+  metadata["related"].split(",").map(&:strip)
 end
 
 def aliases_for(topic)
@@ -70,7 +70,7 @@ def aliases_for(topic)
   return [] unless metadata
   return [] unless metadata["aliases"]
 
-  metadata["aliases"].split(",")
+  metadata["aliases"].split(",").map(&:strip)
 end
 
 def assert_oxford_comma(text)

--- a/topics/assembly/index.md
+++ b/topics/assembly/index.md
@@ -1,5 +1,5 @@
 ---
-aliases: assembler, assembly, assembly-language
+aliases: assembler, assembly-language
 created_by: Kathleen Booth
 display_name: Assembly
 logo: assembly.png

--- a/topics/calculate-pi/index.md
+++ b/topics/calculate-pi/index.md
@@ -1,5 +1,5 @@
 ---
-aliases: calculatepi, calculate-pi
+aliases: calculatepi
 created_by: github
 display_name: Calculate Pi
 github_url: https://github.com/topics/calculate-pi

--- a/topics/elm/index.md
+++ b/topics/elm/index.md
@@ -1,5 +1,5 @@
 ---
-aliases: elm-lang, elmlang, elm-language, elm
+aliases: elm-lang, elmlang, elm-language
 created_by: Evan Czaplicki
 display_name: Elm
 github_url: https://github.com/elm/compiler

--- a/topics/finite-element-method/index.md
+++ b/topics/finite-element-method/index.md
@@ -1,5 +1,5 @@
 ---
-aliases: fem, fea, finite-element-method, finite-element-analysis, finite-elements
+aliases: fem, fea, finite-element-analysis, finite-elements
 display_name: Finite Element Method (FEM)
 short_description: The finite element method (FEM) is a numerical method for solving problems of engineering and mathematical physics.
 logo: finite-element-method.png

--- a/topics/frontend/index.md
+++ b/topics/frontend/index.md
@@ -1,5 +1,5 @@
 ---
-aliases: frontend-developer, frontend
+aliases: frontend-developer
 display_name: Front end
 short_description: Front end is the programming and layout that people see and interact
   with.

--- a/topics/hackathon-kit/index.md
+++ b/topics/hackathon-kit/index.md
@@ -2,7 +2,7 @@
 topic: hackathon-kit
 aliases: hack-kit, resources, resource
 display_name: Hackathon-Kit
-related: game-jam, hacktoberfest, game-off, hackathon-kit, hackathon-organiser, hackathon, hackathons
+related: game-jam, hacktoberfest, game-off, hackathon-organiser, hackathon, hackathons
 short_description: A kit or resource for hackathons.
 wikipedia_url: https://en.wikipedia.org/wiki/Hackathon
 ---

--- a/topics/hackathon-organiser/index.md
+++ b/topics/hackathon-organiser/index.md
@@ -1,8 +1,8 @@
 ---
 topic: hackathon-organiser
-aliases: event-organiser, hack-organiser, hackathon-organizer, hack-organizer, event-organizer
+aliases: event-organiser, hack-organiser, hack-organizer, event-organizer
 display_name: Hackathon-Organiser
-related: game-jam, hacktoberfest, game-off, hackathon-kit, hackathon-organiser, hackathon, hackathons
+related: game-jam, hacktoberfest, game-off, hackathon-kit, hackathon, hackathons
 short_description: A person who organises or runs hackathons.
 wikipedia_url: https://en.wikipedia.org/wiki/Hackathon
 ---

--- a/topics/hackathon/index.md
+++ b/topics/hackathon/index.md
@@ -2,7 +2,7 @@
 topic: hackathon
 aliases: hackfest, codefest, hackday
 display_name: Hackathon
-aliases: hackathons, hackathon
+aliases: hackathons
 related: game-jam, hacktoberfest, game-off, hackathon-kit, hackathon-organiser
 short_description: A hackathon is a gathering where developers collaboratively code in an extreme manner over a short period of time.
 wikipedia_url: https://en.wikipedia.org/wiki/Hackathon

--- a/topics/obofoundry/index.md
+++ b/topics/obofoundry/index.md
@@ -1,5 +1,5 @@
 ---
-aliases: obo, obofoundry
+aliases: obo
 display_name: OBO Foundry
 github_url: https://github.com/OBOFoundry
 logo: obofoundry.png

--- a/topics/terminal/index.md
+++ b/topics/terminal/index.md
@@ -1,5 +1,5 @@
 ---
-aliases: command-line, command-prompt, computer-terminal
+aliases: command-prompt, computer-terminal
 display_name: Terminal
 short_description: The terminal is an interface in which you can type and execute text-based commands. 
 topic: terminal

--- a/topics/ui-design/index.md
+++ b/topics/ui-design/index.md
@@ -1,5 +1,5 @@
 ---
-aliases: user-interface-design, ui-design
+aliases: user-interface-design
 display_name: User interface design
 short_description: The design of user interfaces for machines and software with the focus on maximizing usability and the user experience.
 topic: ui-design


### PR DESCRIPTION
### Thank you for contributing! Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: https://github.com/github/explore/blob/master/CONTRIBUTING.md
- [x] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).

### Which change are you proposing?

  - [ ] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [x] Something that does not neatly fit into the binary options above

---------------------------------------------------------------------

<!-- ⚠️ ... or this section ⚠️ -->
### Something that does not neatly fit into the binary options above

- [x] My suggested edits are not about an existing topic or collection, or at least not a single one
- [x] My suggested edits are not about curating a new topic or collection, or at least not a single one
- [x] My suggested edits conform to the Style Guide and API docs: https://github.com/github/explore/tree/master/docs

When I went to import recently updated topics, I noticed that the `command-line-interface` topic wasn't importing. After some digging, I noticed that both `command-line-interface` and `terminal` shared the `command-line` alias, which I suspect was preventing the import from succeeding.

I updated our test helpers to properly parse aliases and related topics, and as part of that, I found that there were many aliases and related topics that were duplicates. Most of these were duplicating the name of the topic itself, while `command-line` was a duplicate alias across multiple topics.

This PR removes duplicate aliases and related topics and fixes our tests to prevent regressions going forward.

---------------------------------------------------------------------

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**
