### PR TITLE
Remove qu as it's archived

### DIFF
--- a/collections/government/index.md
+++ b/collections/government/index.md
@@ -13,7 +13,6 @@ items:
  - wet-boew/wet-boew
  - CityOfPhiladelphia/flu-shot-spec
  - nysenate/OpenLegislation
- - cfpb/qu
  - openlexington/gethelplex
  - uscensusbureau/citysdk
  - NREL/api-umbrella


### PR DESCRIPTION
### Thank you for contributing! Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: https://github.com/github/explore/blob/master/CONTRIBUTING.md
- [x] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).

### Which change are you proposing?

  - [x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [ ] Something that does not neatly fit into the binary options above

---------------------------------------------------------------------

### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288, size <= 75 kB)
- [x] Content (and my changes are in `index.md`)

The qu project is no longer maintained and has been archived for a year - a great pity. Including it in the list doesn't feel right as bringing it up to date and making it secure is probably a non-trivial task in itself.

---------------------------------------------------------------------
