### PR TITLE
Adds Topic for Statistics

### DIFF
--- a/topics-todo.md
+++ b/topics-todo.md
@@ -53,7 +53,7 @@ Information included in this repository will appear on each topic's respective p
 - [x] [spark](https://github.com/topics/spark/)
 - [ ] [spring-mvc](https://github.com/topics/spring-mvc/)
 - [x] [spring](https://github.com/topics/spring/)
-- [ ] [statistics](https://github.com/topics/statistics/)
+- [x] [statistics](https://github.com/topics/statistics/)
 - [x] [telegram-bot](https://github.com/topics/telegram-bot/)
 - [ ] [test](https://github.com/topics/test/)
 - [ ] [tool](https://github.com/topics/tool/)

--- a/topics/statistics/index.md
+++ b/topics/statistics/index.md
@@ -1,0 +1,9 @@
+---
+display_name: Statistics
+related: data-science, machine-learning, deep-learning, neural-network
+short_description: Statistics is a discipline of mathematics concerned with the collection and analysis of numerical data.
+topic: statistics
+wikipedia_url: https://en.wikipedia.org/wiki/Statistics
+---
+Statistics is a mathematical discipline concerned with developing and studying mathematical methods for collecting, analyzing, interpreting, and presenting large quantities of numerical data. Statistics is a highly interdisciplinary field of study with applications in fields such as physics, chemistry, life sciences, political science, and economics.
+


### PR DESCRIPTION
The topic of Statistics has been identified as a popular topic
for repositories on GitHub. This PR adds the statistics topic to
the list of topics so that a short description, long description,
related topics, and wikipedia URL appear on the topic page.

<!-- Thank you for contributing! -->
### Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: <https://github.com/github/explore/blob/master/CONTRIBUTING.md>.
- [x] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).

### Which change are you proposing?

  - [ ] Suggesting edits to an existing topic or collection
  - [x] Curating a new topic or collection
  - [ ] Something that does not neatly fit into the binary options above

---
### Curating a new topic or collection

- [x] I've formatted my changes as a new folder directory, named for the topic or collection as it appears in the URL on GitHub (e.g. `https://github.com/topics/[NAME]` or `https://github.com/collections/[NAME]`)
- [x] My folder contains a `*.png` image (if applicable) and `index.md`
- [x] All required fields in my `index.md` conform to the Style Guide and API docs: <https://github.com/github/explore/tree/master/docs>

> This topic was identified on the [list of popular topics](https://github.com/github/explore/blob/main/topics-todo.md) used for repositories on GitHub that require more context.
---

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**
