### PR TITLE
Remove too-long created_by: value

### DIFF
--- a/topics/mdx/index.md
+++ b/topics/mdx/index.md
@@ -1,6 +1,5 @@
 ---
 aliases: mdx-js
-created_by: John Otander, Guillermo Rauch, James K. Nelson, Tim Neutkens, Brent Jackson, Jessica Stokes, and more.
 display_name: MDX
 github_url: https://github.com/mdx-js/mdx/
 logo: mdx.png


### PR DESCRIPTION
### Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: <https://github.com/github/explore/blob/master/CONTRIBUTING.md>.
- [x] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).

### Which change are you proposing?

  - [x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [ ] Something that does not neatly fit into the binary options above

---

### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288, size <= 75 kB)
- [x] Content (and my changes are in `index.md`)

Alas, the `created_by:` key in this topic is causing the topic import to fail because it's slightly too long:

<img width="795" alt="import failure" src="https://user-images.githubusercontent.com/17565/144879495-e658f0be-05b7-4051-906b-ca35a93e1339.png">

Rather than cut who gets to have credit on the topic page, let's take the key out and let the linked website provide credit.