### PR TITLE
add xhub

### DIFF
--- a/collections/github-browser-extensions/index.md
+++ b/collections/github-browser-extensions/index.md
@@ -38,6 +38,7 @@ items:
  - matthizou/github-show-avatars
  - dderevjanik/github-vscode-icons
  - npmhub/npmhub
+ - nschloe/xhub
 display_name: GitHub Browser Extensions
 created_by: leereilly
 ---


### PR DESCRIPTION
Extends GitHub pages with support for math (via KaTeX), Chart.js, Mermaid diagrams etc.

<!-- Thank you for contributing! -->
### Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: <https://github.com/github/explore/blob/master/CONTRIBUTING.md>.
- [ ] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).

### Which change are you proposing?

  - [x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [ ] Something that does not neatly fit into the binary options above

---

<!-- ⚠️ Please select either this section... ⚠️ -->
### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288, size <= 75 kB)
- [x] Content (and my changes are in `index.md`)

xhub is great as it addresses the [much requested](https://stackoverflow.com/q/35498525/353337) need for math in GitHub pages. It also adds support for native Chart.js, Mermaid diagrams, embedded Youtube links, and Plotly graphs.