### PR TITLE
Use Bundler 2.3.11 to avoid deprecation warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,4 +82,4 @@ DEPENDENCIES
   safe_yaml
 
 BUNDLED WITH
-   2.1.4
+   2.3.11


### PR DESCRIPTION
This update enables us to suppress the following deprecation warning (from thor 1.1.0 bundled in Bundler 2.1.4):

```
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
```

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

### Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: <https://github.com/github/explore/blob/main/CONTRIBUTING.md>.
- [n/a] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).

### Which change are you proposing?

  - [x] Something that does not neatly fit into the binary options above

### Something that does not neatly fit into the binary options above

- [ ] My suggested edits maintain dependency around development process

### Before this PR
```
Installing Bundler
  Using Bundler 2.1.4 from Gemfile.lock BUNDLED WITH 2.1.4
  /opt/hostedtoolcache/Ruby/3.1.0/x64/bin/gem install bundler -v 2.1.4
  Successfully installed bundler-2.1.4
  1 gem installed
  Took   0.51 seconds
```
https://github.com/github/explore/runs/6033102166?check_suite_focus=true


### Refs.
- https://github.com/rails/thor/pull/761
- https://github.com/rubygems/rubygems/pull/5202
   - and https://github.com/rubygems/rubygems/pull/5260