### PR TITLE
Remove jekyll feed plugin

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,6 @@ title: GitHub Explore Feed
 description: Feed for GitHub Topics and Collections.
 
 plugins:
-  - jekyll-feed
   - jekyll-redirect-from
 
 exclude:
@@ -15,6 +14,7 @@ exclude:
   - Rakefile
   - collections
   - topics
+  - test
 
 collections:
   topics:


### PR DESCRIPTION
We're using the built in json feed capabilities so we don't currently need this
plugin.
