### PR TITLE
Exclude vendor directory

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,8 +13,9 @@ exclude:
   - README.md
   - Rakefile
   - collections
-  - topics
   - test
+  - topics
+  - vendor
 
 collections:
   topics:


### PR DESCRIPTION
This is needed to make sure that we can build for github pages.