### PR TITLE
Test the order of collection items

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,11 @@ source "https://rubygems.org"
 gem "github-pages", group: :jekyll_plugins
 
 group :test do
+  gem "faraday"
   gem "fastimage"
   gem "minitest"
   gem "octokit"
+  gem "pry", require: false
   gem "rake"
   gem "rubocop"
   gem "rubocop-performance"

--- a/test/collections_test.rb
+++ b/test/collections_test.rb
@@ -185,7 +185,7 @@ describe "collections" do
       assert_equal(
         collection_items_minus_new_additions,
         existing_items,
-        "expected collection changes to have been appended to the existing item list",
+        "expected collection changes to have been appended to the existing item list"
       )
     end
   end

--- a/test/collections_test.rb
+++ b/test/collections_test.rb
@@ -175,6 +175,19 @@ describe "collections" do
         end
       end
     end
+
+    it "has the same order and new items are at the end" do
+      collection_items = items_for_collection(collection)
+      existing_items = existing_items_for_collection(collection)
+
+      collection_items_minus_new_additions = collection_items[0, existing_items.length]
+
+      assert_equal(
+        collection_items_minus_new_additions,
+        existing_items,
+        "expected collection changes to have been appended to the existing item list",
+      )
+    end
   end
 
   def repository_exists?(item)
@@ -183,5 +196,9 @@ describe "collections" do
 
   def user_exists?(item)
     client.user(item)
+  end
+
+  def existing_items_for_collection(collection)
+    existing_collection(collection)["items"]
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,6 +7,7 @@ require "octokit"
 IMAGE_WIDTH = 288
 IMAGE_HEIGHT = 288
 MAX_IMAGE_FILESIZE_IN_BYTES = 75_000
+EXPLORE_FEED_URL = "https://explore-feed.github.com/feed.json"
 
 # See https://github.com/franklsf95/ruby-emoji-regex
 # rubocop:disable Layout/LineLength
@@ -56,6 +57,25 @@ end
 
 def client
   @client ||= NewOctokit.new(access_token: ENV["GITHUB_TOKEN"])
+end
+
+def existing_explore_feed
+  @_existing_explore_feed ||= begin
+    conn = Faraday.new(EXPLORE_FEED_URL) do |f|
+      f.request :json
+      f.response :json
+    end
+
+    conn.get
+  end
+end
+
+def existing_collection(name)
+  @_existing_collections ||= {}
+
+  @_existing_collections[name] ||= existing_explore_feed.body["collections"].find do |collection|
+    collection["name"] == name
+  end
 end
 
 def valid_uri_scheme?(scheme)


### PR DESCRIPTION
In this PR:
  - add the faraday gem
  - add pry
  - add a method to fetch and memoize the existing explore json
  - add a test to check that the proposed collection changes are the in the same
  order as the existing collection items and that new items are appended to the
  list.

Why?
  - We spend time checking this manually and writing responses to PR authors
  when we could just rely on the test to fail
