### PR TITLE
Minor: mark argo-floats and utility as done

### DIFF
--- a/topics-todo.md
+++ b/topics-todo.md
@@ -60,7 +60,7 @@ Information included in this repository will appear on each topic's respective p
 - [ ] [tool](https://github.com/topics/tool/)
 - [ ] [tutorial](https://github.com/topics/tutorial/)
 - [x] [ui](https://github.com/topics/ui/)
-- [ ] [utility](https://github.com/topics/utility/)
+- [x] [utility](https://github.com/topics/utility/)
 - [x] [video](https://github.com/topics/video/)
 - [x] [web](https://github.com/topics/web/)
 - [x] [website](https://github.com/topics/website/)

--- a/topics-todo.md
+++ b/topics-todo.md
@@ -9,7 +9,7 @@ Information included in this repository will appear on each topic's respective p
 - [x] [animation](https://github.com/topics/animation/)
 - [x] [ansible-role](https://github.com/topics/ansible-role/)
 - [ ] [app](https://github.com/topics/app/)
-- [ ] [argo-floats](https://github.com/topics/argo-floats/)
+- [x] [argo-floats](https://github.com/topics/argo-floats/)
 - [x] [authentication](https://github.com/topics/authentication/)
 - [ ] [automation](https://github.com/topics/automation/)
 - [x] [boilerplate](https://github.com/topics/boilerplate/)


### PR DESCRIPTION
Signed-off-by: Andy Piper <andypiper@users.noreply.github.com>

- [X] My suggested edits are not about an existing topic or collection, or at least not a single one
- [X] My suggested edits are not about curating a new topic or collection, or at least not a single one
- [X] My suggested edits conform to the Style Guide and API docs: https://github.com/github/explore/tree/main/docs

The _argo-floats_ and _utility_ topics are now populated, and should have been marked as complete in `topics-todo.md` as part of their respective commits. This small update does exactly that 👍🏻 