### PR TITLE
Update api calls to graphql for batching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,3 +25,5 @@ jobs:
 
       - name: Build and test with Rake
         run: bundle exec rake ${{ matrix.test_type }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/collections/game-engines/index.md
+++ b/collections/game-engines/index.md
@@ -15,7 +15,6 @@ items:
  - superpowers/superpowers-core
  - AtomicGameEngine/AtomicGameEngine
  - 4ian/GDevelop
- - CRYTEK/CRYENGINE
  - urho3d/Urho3D
  - benoit-dumas/OpenRTS
  - photonstorm/phaser

--- a/test/collections_test.rb
+++ b/test/collections_test.rb
@@ -97,9 +97,7 @@ describe "collections" do
         cache_users_exist_check!(users_to_check)
 
         repos_to_check.each do |repo|
-          unless repository_exists?(repo)
-            errors << "#{collection}: #{repo} has been renamed"
-          end
+          errors << "#{collection}: #{repo} has been renamed" unless repository_exists?(repo)
         end
 
         users_to_check.each do |login|

--- a/test/collections_test.rb
+++ b/test/collections_test.rb
@@ -40,12 +40,19 @@ describe "collections" do
 
       it "fails if a repository does not exist or is private" do
         errors = []
+        repos_to_check = []
 
         items_for_collection(collection).each do |item|
           next unless item.match?(USERNAME_AND_REPO_REGEX)
 
-          unless repository_exists?(item)
-            errors << "#{collection}: #{item} does not exist or is private"
+          repos_to_check << item
+        end
+
+        cache_repos_exist_check!(repos_to_check)
+
+        repos_to_check.each do |repo|
+          unless repository_exists?(repo)
+            errors << "#{collection}: #{repo} does not exist or is private"
           end
         end
 
@@ -54,11 +61,18 @@ describe "collections" do
 
       it "fails if a user or organization does not exist" do
         errors = []
+        users_to_check = []
 
         items_for_collection(collection).each do |item|
           next unless item.match?(USERNAME_REGEX)
 
-          errors << "#{collection}: #{item} does not exist" unless user_exists?(item)
+          users_to_check << item
+        end
+
+        cache_users_exist_check!(users_to_check)
+
+        users_to_check.each do |login|
+          errors << "#{collection}: #{login} does not exist" unless user_exists?(login)
         end
 
         assert_empty errors
@@ -66,15 +80,30 @@ describe "collections" do
 
       it "fails if a user, organization, or repository has been renamed" do
         errors = []
+        repos_to_check = []
+        users_to_check = []
 
         items_for_collection(collection).each do |item|
           next unless item.match?(USERNAME_AND_REPO_REGEX) || item.match?(USERNAME_REGEX)
 
           if item.match?(USERNAME_AND_REPO_REGEX)
-            errors << "#{collection}: #{item} has been renamed" unless repository_exists?(item)
+            repos_to_check << item
           else
-            errors << "#{collection}: #{item} has been renamed" unless user_exists?(item)
+            users_to_check << item
           end
+        end
+
+        cache_repos_exist_check!(repos_to_check)
+        cache_users_exist_check!(users_to_check)
+
+        repos_to_check.each do |repo|
+          unless repository_exists?(repo)
+            errors << "#{collection}: #{repo} has been renamed"
+          end
+        end
+
+        users_to_check.each do |login|
+          errors << "#{collection}: #{login} has been renamed" unless user_exists?(login)
         end
 
         assert_empty errors

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -64,7 +64,7 @@ class NewOctokit < Octokit::Client
 end
 
 def client
-  @client ||= NewOctokit.new(access_token: ENV["GITHUB_TOKEN"])
+  @client ||= NewOctokit.new(access_token: ENV.fetch("GITHUB_TOKEN"))
 end
 
 def graphql_query(query)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -68,16 +68,14 @@ def client
 end
 
 def graphql_query(query)
-  jsonified_query = { query: query }.to_json
+  jsonified_query = { query: }.to_json
   client.post(GRAPHQL_ENDPOINT, jsonified_query).data
 end
 
 def cache_users_exist_check!(user_logins)
   results = graphql_query(graphql_query_string_for_user_logins(user_logins))
 
-  if results
-    results.each { |login, result| client.users[login] = result }
-  end
+  results.each { |login, result| client.users[login] = result } if results
 end
 
 def cache_repos_exist_check!(repos)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,7 +35,7 @@ class NewOctokit < Octokit::Client
   end
 
   def repository?(item)
-    return repos[item] if repos.has_key?(item)
+    return repos[item] if repos.key?(item)
 
     repos[item] = super
   rescue Octokit::TooManyRequests
@@ -44,7 +44,7 @@ class NewOctokit < Octokit::Client
   end
 
   def user(item)
-    return users[item] if users.has_key?(item)
+    return users[item] if users.key?(item)
 
     users[item] = super
   rescue Octokit::TooManyRequests


### PR DESCRIPTION
This PR:
  - introduces two new api calls that use the graphql api to check all of the
  users/repos in a collection at once and then cache them so we don't make a
  single call to the REST api for each item
  - Now that we're able to run the tests on the full collection of collections, we've discovered a new repo that has been archived and this PR removes it from the collection it was part of (`CRYTEK/CRYENGINE` in `game-engines`)