### PR TITLE
Replace references to Travis CI with GitHub Actions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,12 +102,13 @@ This repository includes [a list of the most-used GitHub topics that don't yet h
 
 ## Running tests
 
-There are some lint tests in place to ensure each topic is formatted in the way we expect. Travis
-CI will run the tests automatically. If you want to run the tests yourself locally, you will need
-Ruby and Bundler installed.
+There are some lint tests in place to ensure each topic is formatted in the way we expect. GitHub
+Actions will run the tests automatically. If you want to run the tests yourself locally, you will
+need Ruby and Bundler installed.
 
 You can run the tests using:
 
 ```bash
-script/cibuild
+bundle install
+bundle exec rubocop
 ```

--- a/README.md
+++ b/README.md
@@ -10,12 +10,15 @@ If you want to suggest edits to an existing topic page or collection, or curate 
 
 ## Running tests
 
-There are some lint tests in place to ensure each topic is formatted in the way we expect. Travis CI will run the tests automatically. If you want to run the tests yourself locally, you will need Ruby and Bundler installed.
+There are some lint tests in place to ensure each topic is formatted in the way we expect. GitHub
+Actions will run the tests automatically. If you want to run the tests yourself locally, you will
+need Ruby and Bundler installed.
 
 You can run the tests using:
 
 ```bash
-script/cibuild
+bundle install
+bundle exec rubocop
 ```
 
 ## Licenses


### PR DESCRIPTION
<!-- Thank you for contributing! -->
### Please confirm this pull request meets the following requirements:

- [X] I followed the contributing guidelines: <https://github.com/github/explore/blob/main/CONTRIBUTING.md>.
- [X] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).

### Which change are you proposing?

  - [ ] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [X] Something that does not neatly fit into the binary options above

---

<!-- ⚠️ ... or this section ⚠️ -->
### Something that does not neatly fit into the binary options above

- [X] My suggested edits are not about an existing topic or collection, or at least not a single one
- [X] My suggested edits are not about curating a new topic or collection, or at least not a single one
- [X] My suggested edits conform to the Style Guide and API docs: https://github.com/github/explore/tree/main/docs

Travis CI was removed in commit 6790ba2b0fa84884a7d05f49b0fbb4980c7a0a98 after being replaced with equivalent GitHub Actions workflows. This change simply updates the text in the `CONTRIBUTING.md` and `README.md` files to reflect that previous change, ie to mention GitHub Actions instead of Travis CI.

I've also replaced the references to the `script/cibuild`, which was deleted in 7fb6fba1bef660d68514125a76925a2e990ff6ea, and is now performed by `.github/workflows/lint.yml` instead.

Cheers.

---

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**
