### PR TITLE
consolidate conflict.yml to a single job with multiple conditional steps

### DIFF
--- a/.github/workflows/conflict.yml
+++ b/.github/workflows/conflict.yml
@@ -21,5 +21,7 @@ jobs:
           echo "Thank you!"
           exit 1
         if: contains(github.event.pull_request.body, '- [ ] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).')
+        name: Fail
       - run: exit 0
         if: contains(github.event.pull_request.body, '- [x] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).')
+        name: Succeed

--- a/.github/workflows/conflict.yml
+++ b/.github/workflows/conflict.yml
@@ -10,9 +10,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  fail:
+  check:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.body, '- [ ] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).')
     steps:
       - run: |
           echo "In order to review this pull request for acceptance, we need to make sure that all of the prerequisites are satisfied."
@@ -21,9 +20,6 @@ jobs:
           echo "This is a requirement to maintain a high level of independence in this project. Please update if you are able to verify that you meet that requirement."
           echo "Thank you!"
           exit 1
-
-  succeed:
-    runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.body, '- [x] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).')
-    steps:
+        if: contains(github.event.pull_request.body, '- [ ] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).')
       - run: exit 0
+        if: contains(github.event.pull_request.body, '- [x] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).')

--- a/.github/workflows/conflict.yml
+++ b/.github/workflows/conflict.yml
@@ -7,7 +7,6 @@ on:
       - reopened
       - ready_for_review
       - edited
-  workflow_dispatch:
 
 jobs:
   check:


### PR DESCRIPTION
<!-- Thank you for contributing! -->
### Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: <https://github.com/github/explore/blob/main/CONTRIBUTING.md>.
- [x] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).

### Which change are you proposing?

  - [ ] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [x] Something that does not neatly fit into the binary options above

---

<!-- ⚠️ ... or this section ⚠️ -->
### Something that does not neatly fit into the binary options above

- [x] My suggested edits are not about an existing topic or collection, or at least not a single one
- [x] My suggested edits are not about curating a new topic or collection, or at least not a single one
- [x] My suggested edits conform to the Style Guide and API docs: https://github.com/github/explore/tree/main/docs

conflict.yml previously was two jobs, which caused one to be skipped. However, this skipped check showed in the pull UI. With conditional steps instead of conditional jobs, the same checks can be run without a skipped job showing in the UI.

---

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**
