### PR TITLE
adds wiki as a new topic

### DIFF
--- a/topics/wiki/index.md
+++ b/topics/wiki/index.md
@@ -1,0 +1,13 @@
+---
+aliases: wikis
+display_name: Wiki
+related: mediawiki, wikipedia
+short_description: Wikis are public, online repositories of information; created and often edited by many writers.
+topic: wiki
+wikipedia_url: https://en.wikipedia.org/wiki/Wiki
+---
+Popularized by [Wikipedia](https://en.wikipedia.org), wikis aim to be a comprehensive reference material to either specific or general subjects. Wikis typically consist of lots of individual articles, updated by a team of volunteer writers.
+
+Wikis are frequently hosted using open source software due to the open source nature of HTML; a popular example amongst these projects is [MediaWiki](https://www.mediawiki.org/), being repsonsible for Wikipedia's backend.
+
+GitHub allows for each repository to host [a wiki of their own](https://docs.github.com/en/communities/documenting-your-project-with-wikis/about-wikis), allowing for detailed documentation of any repository's function. GitHub wikis may be relevant to continued development, relevant to those utilizing a repository's application, or a repository's entire purpose.


### PR DESCRIPTION
<!-- Thank you for contributing! -->
### Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: <https://github.com/github/explore/blob/main/CONTRIBUTING.md>.
- [x] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).

### Which change are you proposing?

  - [ ] Suggesting edits to an existing topic or collection
  - [x] Curating a new topic or collection
  - [ ] Something that does not neatly fit into the binary options above

---

<!-- ⚠️ ... or this section ⚠️ -->
### Curating a new topic or collection

- [x] I've formatted my changes as a new folder directory, named for the topic or collection as it appears in the URL on GitHub (e.g. `https://github.com/topics/[NAME]` or `https://github.com/collections/[NAME]`)
- [x] My folder contains a `*.png` image (if applicable) and `index.md`
- [x] All required fields in my `index.md` conform to the Style Guide and API docs: <https://github.com/github/explore/tree/main/docs>

> Containing [over 2,800 repositories](https://github.com/topics/wiki), and considering MediaWiki's existence as a [curated topic](https://github.com/topics/mediawiki), I thought it important to also detail the general concept, too. `wiki` makes for a good topic, and, as I've used it, there's good reason for those with an inability to code to still initialize GitHub wikis as a cost-effective way of hosting one's own wiki.

---

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**
