### PR TITLE
Added p5play, a JS game engine which has +500 stars on GitHub

### DIFF
--- a/collections/javascript-game-engines/index.md
+++ b/collections/javascript-game-engines/index.md
@@ -15,6 +15,7 @@ items:
  - WhitestormJS/whs.js
  - GooTechnologies/goojs
  - shakiba/planck.js
+ - quinton-ashley/p5play
  - Irrelon/ige
  - 4ian/GDevelop
  - mrdoob/three.js


### PR DESCRIPTION
I added p5play right below planck.js because it uses planck.js for physics simulation.

<!-- Thank you for contributing! -->
### Please confirm this pull request meets the following requirements:

- [yes] I followed the contributing guidelines: <https://github.com/github/explore/blob/main/CONTRIBUTING.md>.
- [no] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).

### Which change are you proposing?

  - [yes] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [ ] Something that does not neatly fit into the binary options above

---

<!-- ⚠️ Please select either this section... ⚠️ -->
### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288, size <= 75 kB)
- [yes] Content (and my changes are in `index.md`)

p5play is a notable JavaScript game engine used by many US colleges and high schools:

https://p5play.org