### PR TITLE
Adding the lume static site generator in list

### DIFF
--- a/collections/static-site-generators/index.md
+++ b/collections/static-site-generators/index.md
@@ -24,6 +24,7 @@ items:
  - withastro/astro
  - tlienart/Franklin.jl
  - getzola/zola
+ - lumeland/lume
 display_name: Static Site Generators
 created_by: jakejarvis
 ---


### PR DESCRIPTION
Lume is a static site generator for Deno
### Please confirm this pull request meets the following requirements:

-   [x]  I followed the contributing guidelines: <https://github.com/github/explore/blob/main/CONTRIBUTING.md>.
-   [x]  I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).

### Which change are you proposing?

-   [X]  Suggesting edits to an existing topic or collection
-   [ ]  Curating a new topic or collection
-   [ ]  Something that does not neatly fit into the binary options above

* * * * *

### Curating a new topic or collection

-   [ ]  I've formatted my changes as a new folder directory, named for the topic or collection as it appears in the URL on GitHub (e.g. `https://github.com/topics/[NAME]` or `https://github.com/collections/[NAME]`)
-   [ ]  My folder contains a `*.png` image (if applicable) and `index.md`
-   [ ]  All required fields in my `index.md` conform to the Style Guide and API docs: <https://github.com/github/explore/tree/main/docs>

> This is a popular topic with many repos and deserves additional information.
