### PR TITLE
Fix line breaks in `error-propagation` topic

### DIFF
--- a/topics/error-propagation/index.md
+++ b/topics/error-propagation/index.md
@@ -7,8 +7,6 @@ topic: error-propagation
 wikipedia_url: https://en.wikipedia.org/wiki/Propagation_of_uncertainty
 ---
 
-Error (or uncertainty) propagation is the practice of analyzing and accounting for the effect of numeric quantities' uncertainties on the results of functions
-that involve them.
-When variables used in a function or mathematical operation have errors (due to [measurement uncertainties](https://en.wikipedia.org/wiki/Observational_error),
-[random fluctuations](https://en.wikipedia.org/wiki/Statistical_fluctuations), sample variance, etc.), error propagation can be used to determine the resulting
-error of the function's output.
+Error (or uncertainty) propagation is the practice of analyzing and accounting for the effect of numeric quantities' uncertainties on the results of functions that involve them.
+
+When variables used in a function or mathematical operation have errors (due to [measurement uncertainties](https://en.wikipedia.org/wiki/Observational_error), [random fluctuations](https://en.wikipedia.org/wiki/Statistical_fluctuations), sample variance, etc.), error propagation can be used to determine the resulting error of the function's output.


### PR DESCRIPTION
### Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: <https://github.com/github/explore/blob/main/CONTRIBUTING.md>.
- [x] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).

### Which change are you proposing?

  - [x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [ ] Something that does not neatly fit into the binary options above

---

### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288, size <= 75 kB)
- [x] Content (and my changes are in `index.md`)

For some reason, markdown was rendering single line breaks in the source text as actual line breaks, leading to an improperly formatted topic page:

![image](https://user-images.githubusercontent.com/36030084/230240928-af9da508-6c2b-4dc7-88ce-a13e6681f1d5.png)

This pull request simply removes those extraneous line breaks.

---

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**