### PR TITLE
Remove adobe/brackets since it is deprecated

### DIFF
--- a/collections/text-editors/index.md
+++ b/collections/text-editors/index.md
@@ -1,6 +1,5 @@
 ---
 items:
- - adobe/brackets
  - limetext/lime
  - textmate/textmate
  - neovim/neovim


### PR DESCRIPTION
<!-- Thank you for contributing! -->
### Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: <https://github.com/github/explore/blob/main/CONTRIBUTING.md>.
- [x] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).

### Which change are you proposing?

  - [x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [ ] Something that does not neatly fit into the binary options above

---

<!-- ⚠️ Please select either this section... ⚠️ -->
### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288, size <= 75 kB)
- [x] Content (and my changes are in `index.md`)

# Explanation

Remove adobe/brackets since it is deprecated and not recommended to use.