### PR TITLE
Create Github Accelerator 2023 cohort.md

### DIFF
--- a/collections/Github Accelerator 2023 cohort.md
+++ b/collections/Github Accelerator 2023 cohort.md
@@ -1,0 +1,26 @@
+---
+Projects:
+ - analogjs/analog
+ - Atri-Labs/atrilabs-engine
+ - bigskysoftware/htmx
+ - code-hike/codehike
+ - DioxusLabs/dioxus
+ - EddieHubCommunity/LinkFree
+ - FashionFreedom/Seamly2D
+ - fastai/nbdev
+ - formbricks/formbricks
+ - GyulyVGC/sniffnet
+ - JessicaTegner/pypandoc
+ - mockoon/mockoon
+ - nuxt/nuxt
+ - responsively-org/responsively-app
+ - simonw/datasette
+ - spyder-ide/spyde
+ - strawberry-graphql/strawberry
+ - termux/termux-app
+ - TimothyStiles/poly
+ - trpc/trpc
+display_name: GitHub Accelerator Cohort 2023
+created_by: karasowles
+---
+GitHub Accelerator is an exploration into what sustainable open source could look like: a 10-week program where open source maintainers receive an initial sponsorship to work on their project, paired with guidance and workshops from open source leaders, with an end goal of building durable streams of funding for their work. 


### PR DESCRIPTION
Proposal to add a collection of the GitHub Accelerator 2023 Cohort. Would be a great way to share the list of projects with folks. If this isn't a good use of GitHub Collections, though, please let me know!

<!-- Thank you for contributing! -->
### Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: <https://github.com/github/explore/blob/main/CONTRIBUTING.md>.
- [ ] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).

I am not a maintainer, creator, contractor, or employee of any of the projects in this list. I work at GitHub, and I run the Accelerator. If this is a conflict that doesn't match the purpose of Collections, please reject my PR.

### Which change are you proposing?

  - [ ] Suggesting edits to an existing topic or collection
  - [x] Curating a new topic or collection
  - [ ] Something that does not neatly fit into the binary options above

---
### Curating a new topic or collection

- [x] I've formatted my changes as a new folder directory, named for the topic or collection as it appears in the URL on GitHub (e.g. `https://github.com/topics/[NAME]` or `https://github.com/collections/[NAME]`)
- [x] My folder contains a `*.png` image (if applicable) and `index.md`
  - Didn't add an image, not sure if I have to?
  - Tried to add it as an index.md but apologies if I did it wrong
- [x] All required fields in my `index.md` conform to the Style Guide and API docs: <https://github.com/github/explore/tree/main/docs>

I'm sure I've made some mistakes with how I set this up. If you think this Collection is a good fit, thanks in advance for the help fixing any mistakes :)

Why this Collection?
Multiple folks have mentioned it would be great to have a Collection that they could share around of the projects that are participating in the GitHub Accelerator. These projects are publicly participating in a program that's built to help them find answers around long term sustainability, and there's a lot of interest in seeing how this works out for projects, and what they learn. A Collection seems like a much more useful form to share than a blog post etc, since it's native to GitHub where the projects are based!

---

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**
