### PR TITLE
Sort ascending a JavaScript frameworks list & add hybrids

### DIFF
--- a/collections/front-end-javascript-frameworks/index.md
+++ b/collections/front-end-javascript-frameworks/index.md
@@ -1,35 +1,36 @@
 ---
 items:
- - solidjs/solid
- - marko-js/marko
- - MithrilJS/mithril.js
  - angular/angular
+ - aurelia/aurelia
+ - aurelia/framework
+ - BuilderIO/qwik
+ - Daemonite/material
+ - dojo/dojo
  - emberjs/ember.js
- - knockout/knockout
- - tastejs/todomvc
- - spine/spine
- - vuejs/vue
- - Polymer/polymer
  - facebook/react
  - finom/seemple
- - aurelia/framework
- - optimizely/nuclear-js
- - jashkenas/backbone
- - dojo/dojo
- - jorgebucaran/hyperapp
- - riot/riot
- - Daemonite/material
- - lit/lit
- - aurelia/aurelia
- - sveltejs/svelte
- - neomjs/neo
- - preactjs/preact
- - ionic-team/stencil
- - withastro/astro
- - BuilderIO/qwik
- - vercel/next.js
  - gatsbyjs/gatsby
+ - hybridsjs/hybrids
+ - ionic-team/stencil
+ - jashkenas/backbone
+ - jorgebucaran/hyperapp
+ - knockout/knockout
+ - lit/lit
+ - marko-js/marko
+ - MithrilJS/mithril.js
+ - neomjs/neo
+ - optimizely/nuclear-js
+ - Polymer/polymer
+ - preactjs/preact
+ - riot/riot
+ - solidjs/solid
+ - spine/spine
  - sveltejs/kit
+ - sveltejs/svelte
+ - tastejs/todomvc
+ - vercel/next.js
+ - vuejs/vue
+ - withastro/astro
 
 display_name: Front-end JavaScript frameworks
 created_by: jonrohan


### PR DESCRIPTION
<!-- Thank you for contributing! -->
### Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: <https://github.com/github/explore/blob/main/CONTRIBUTING.md>.
- [ ] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).

### Which change are you proposing?

  - [x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [ ] Something that does not neatly fit into the binary options above

---

<!-- ⚠️ Please select either this section... ⚠️ -->
### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288, size <= 75 kB)
- [x] Content (and my changes are in `index.md`)

Users usually look at the top of the lists, thinking that at the top are the bests, or most recent projects. I suggest using ascending order, to avoid a situation where someone uses that behavior to get a better opening on the project. 

The PR includes adding [hybrids](https://github.com/hybridsjs/hybrids), of which I am an author. I don't know if it excludes me from being accepted (the second check in the PR template).

---

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**
