### PR TITLE
Softened language around conflicts of interest

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 ### Please confirm this pull request meets the following requirements:
 
 - [ ] I followed the contributing guidelines: <https://github.com/github/explore/blob/main/CONTRIBUTING.md>.
-- [ ] I have no affiliation with the project I am suggesting (as a maintainer, creator, contractor, or employee).
+- [ ] I am not the sole author or employee of a company who created the topic or collection I'm changing.
 
 ### Which change are you proposing?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ This repository includes [a list of the most-used GitHub topics that don't yet h
 
 ## Guidelines
 
-* Avoid conflicts of interest. Maintainers of a project cannot add a topic or collection for their own project. If a topic is popular enough to warrant inclusion, someone else will add or improve it.
+* Avoid conflicts of interest. These should be of general community interest, not a marketing vehicle for a product or a personal prorject. If you are a direct employee of a company creating the project, or the createor and sole maintainer, it's unlikely to be accepted.
 
 ## Running tests
 


### PR DESCRIPTION
The goal behind this policy is to prevent people from advertising
a product or a pet project, but the wording restricted _anyone_
with a maintainer/contributor interest in a project from changing
the topic, which was too restrictive. This change makes the wording
more closely aligned with the actual policy.
