### PR TITLE
flathub/index.md: fix broken spacing in description

### DIFF
--- a/topics/flathub/index.md
+++ b/topics/flathub/index.md
@@ -7,5 +7,4 @@ topic: flathub
 url: https://flathub.org
 related: flatpak, linux
 ---
-Flathub is the place to get and distribute apps for all of desktop Linux. It is powered by Flatpak, 
-allowing Flathub apps to run on almost any Linux distribution.
+Flathub is the place to get and distribute apps for all of desktop Linux. It is powered by Flatpak, allowing Flathub apps to run on almost any Linux distribution.


### PR DESCRIPTION
<!-- Thank you for contributing! -->
### Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: <https://github.com/github/explore/blob/main/CONTRIBUTING.md>.
- [x] I am not the sole author or employee of a company who created the topic or collection I'm changing.

### Which change are you proposing?

  - [x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [ ] Something that does not neatly fit into the binary options above

Currently, the description has broken spacing as seen in <https://github.com/topics/flathub>, this PR fixes it by making it continuous.

![image](https://github.com/github/explore/assets/26346867/e1ea92f0-fbdc-4682-8a39-12c6acbbc310)

---
