### PR TITLE
Update renamed repo

### DIFF
--- a/collections/react-ui/index.md
+++ b/collections/react-ui/index.md
@@ -18,7 +18,7 @@ items:
  - praveenjuge/myna/
  - TailGrids/tailwind-ui-components
  - htmlstreamofficial/preline
- - shadcn/ui
+ - shadcn-ui/ui
  - primefaces/primereact
  - nextui-org/nextui
  - chakra-ui/chakra-ui


### PR DESCRIPTION
Updating `shadcn/ui` to `shadcn-ui/ui` based on failing CI on https://github.com/github/explore/pull/3807