### PR TITLE
add Basti to the devops-tools collection

### DIFF
--- a/collections/devops-tools/index.md
+++ b/collections/devops-tools/index.md
@@ -41,6 +41,7 @@ items:
  - devtron-labs/devtron
  - livecycle/preevy 
  - cloudposse/atmos
+ - basti-app/basti
  
 display_name: DevOps tools
 ---


### PR DESCRIPTION
### Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: <https://github.com/github/explore/blob/main/CONTRIBUTING.md>.
- [x] I am not the sole author or employee of a company who created the topic or collection I'm changing.

### Which change are you proposing?

  - [x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [ ] Something that does not neatly fit into the binary options above

---

<!-- ⚠️ Please select either this section... ⚠️ -->
### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288, size <= 75 kB)
- [x] Content (and my changes are in `index.md`)

I'm suggesting adding [Basti](https://github.com/basti-app/basti) to the collection of DevOps tools since Basti solves a common problem with the idle cost of all the native AWS solutions for secure remote connection to network-protected resources like RRS or Elasticache cluster in a private VPC subnet.

To be clear, I'm the author of Basti. I read the CONTRIBUTING.md and this PR template and didn't find any restrictions on who can suggest tools for topics. Sorry if I missed this part somewhere.

---

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**
