### PR TITLE
Cleanup Hacktoberfest topic

### DIFF
--- a/topics/hacktoberfest/index.md
+++ b/topics/hacktoberfest/index.md
@@ -10,8 +10,5 @@ aliases: hacktoberfest-contributions, hacktoberfest-repo, hacktoberfest-contribu
 ---
 **Hacktoberfest** is a month-long celebration of open source projects, their maintainers, and the entire community of contributors. Each October, open source maintainers give new contributors extra attention as they guide developers through their first pull requests on GitHub.
 
-# By country
-[🇳🇵 Nepal](https://github.com/topics/hacktoberfestnepal) &bull; [🇮🇩 Indonesia](https://github.com/topics/hacktoberfest-indonesia) &bull; **[🇮🇳 India](https://github.com/topics/hacktoberfest-india)** ([West Bengal](https://github.com/topics/hacktoberfest-westbengal)) &bull; [🇧🇷 Brazil](https://github.com/topics/hacktoberfest-brasil)
-
 # By programming language
 [JavaScript](https://github.com/topics/hacktoberfest?l=javascript) &bull; [Python](https://github.com/topics/hacktoberfest?l=python) &bull; [Java](https://github.com/topics/hacktoberfest?l=java)

--- a/topics/hacktoberfest/index.md
+++ b/topics/hacktoberfest/index.md
@@ -17,4 +17,4 @@ aliases: hacktoberfest-contributions, hacktoberfest-repo, hacktoberfest-contribu
 [🇳🇵 Nepal](https://github.com/topics/hacktoberfestnepal) &bull; [🇮🇩 Indonesia](https://github.com/topics/hacktoberfest-indonesia) &bull; **[🇮🇳 India](https://github.com/topics/hacktoberfest-india)** ([West Bengal](https://github.com/topics/hacktoberfest-westbengal)) &bull; [🇧🇷 Brazil](https://github.com/topics/hacktoberfest-brasil)
 
 # By programming language
-[React.js](https://github.com/topics/react-hacktoberfest) ([topic](https://github.com/topics/react)) &bull; [Python](https://github.com/topics/hacktoberfestpy) ([topic](https://github.com/topics/python)) &bull; [Java](https://github.com/topics/hacktoberfest-java) ([topic](https://github.com/topics/java))
+[JavaScript](https://github.com/topics/hacktoberfest?l=javascript) &bull; [Python](https://github.com/topics/hacktoberfest?l=python) &bull; [Java](https://github.com/topics/hacktoberfest?l=java)

--- a/topics/hacktoberfest/index.md
+++ b/topics/hacktoberfest/index.md
@@ -13,9 +13,6 @@ aliases: hacktoberfest-contributions, hacktoberfest-repo, hacktoberfest-contribu
 # By year
 [2017](https://github.com/topics/hacktoberfest2017) &bull; [2018](https://github.com/topics/hacktoberfest2018) &bull; [2019](https://github.com/topics/hacktoberfest2019) &bull; [2020](https://github.com/topics/hacktoberfest2020) &bull; [2021](https://github.com/topics/hacktoberfest2021) &bull; [2022](https://github.com/topics/hacktoberfest2022) &bull; [2023](https://github.com/topics/hacktoberfest2023) &bull; [2024](https://github.com/topics/hacktoberfest2024) &bull; [2025](https://github.com/topics/hacktoberfest2025) &bull; [2026](https://github.com/topics/hacktoberfest2026)
 
-# [By status](https://github.com/topics/hacktoberfest-status)
-[accepted](https://github.com/topics/hacktoberfest-accepted) &bull; [approved](https://github.com/topics/hacktoberfest-approved)
-
 # By country
 [🇳🇵 Nepal](https://github.com/topics/hacktoberfestnepal) &bull; [🇮🇩 Indonesia](https://github.com/topics/hacktoberfest-indonesia) &bull; **[🇮🇳 India](https://github.com/topics/hacktoberfest-india)** ([West Bengal](https://github.com/topics/hacktoberfest-westbengal)) &bull; [🇧🇷 Brazil](https://github.com/topics/hacktoberfest-brasil)
 

--- a/topics/hacktoberfest/index.md
+++ b/topics/hacktoberfest/index.md
@@ -10,9 +10,6 @@ aliases: hacktoberfest-contributions, hacktoberfest-repo, hacktoberfest-contribu
 ---
 **Hacktoberfest** is a month-long celebration of open source projects, their maintainers, and the entire community of contributors. Each October, open source maintainers give new contributors extra attention as they guide developers through their first pull requests on GitHub.
 
-# By year
-[2017](https://github.com/topics/hacktoberfest2017) &bull; [2018](https://github.com/topics/hacktoberfest2018) &bull; [2019](https://github.com/topics/hacktoberfest2019) &bull; [2020](https://github.com/topics/hacktoberfest2020) &bull; [2021](https://github.com/topics/hacktoberfest2021) &bull; [2022](https://github.com/topics/hacktoberfest2022) &bull; [2023](https://github.com/topics/hacktoberfest2023) &bull; [2024](https://github.com/topics/hacktoberfest2024) &bull; [2025](https://github.com/topics/hacktoberfest2025) &bull; [2026](https://github.com/topics/hacktoberfest2026)
-
 # By country
 [🇳🇵 Nepal](https://github.com/topics/hacktoberfestnepal) &bull; [🇮🇩 Indonesia](https://github.com/topics/hacktoberfest-indonesia) &bull; **[🇮🇳 India](https://github.com/topics/hacktoberfest-india)** ([West Bengal](https://github.com/topics/hacktoberfest-westbengal)) &bull; [🇧🇷 Brazil](https://github.com/topics/hacktoberfest-brasil)
 

--- a/topics/hacktoberfest/index.md
+++ b/topics/hacktoberfest/index.md
@@ -16,8 +16,5 @@ aliases: hacktoberfest-contributions, hacktoberfest-repo, hacktoberfest-contribu
 # By country
 [🇳🇵 Nepal](https://github.com/topics/hacktoberfestnepal) &bull; [🇮🇩 Indonesia](https://github.com/topics/hacktoberfest-indonesia) &bull; **[🇮🇳 India](https://github.com/topics/hacktoberfest-india)** ([West Bengal](https://github.com/topics/hacktoberfest-westbengal)) &bull; [🇧🇷 Brazil](https://github.com/topics/hacktoberfest-brasil)
 
-# By contribution type
-[Issue](https://github.com/topics/hacktoberfest-issue) &bull; [Pull Request](https://github.com/topics/hacktoberfest-pr)
-
 # By programming language
 [React.js](https://github.com/topics/react-hacktoberfest) ([topic](https://github.com/topics/react)) &bull; [Python](https://github.com/topics/hacktoberfestpy) ([topic](https://github.com/topics/python)) &bull; [Java](https://github.com/topics/hacktoberfest-java) ([topic](https://github.com/topics/java))


### PR DESCRIPTION
### Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: <https://github.com/github/explore/blob/main/CONTRIBUTING.md>.
- [x] I am not the sole author or employee of a company who created the topic or collection I'm changing.

_I do work at DigitalOcean and am on the core Hacktoberfest team, but per https://github.com/github/explore/pull/3885#issuecomment-1703648392 I'm clear to check this checkbox._

### Which change are you proposing?

  - [x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [ ] Something that does not neatly fit into the binary options above

---

### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288, size <= 75 kB)
- [x] Content (and my changes are in `index.md`)

I raised some concerns about recent changes to this topic over in https://github.com/github/explore/pull/3995#issuecomment-1810481212, with the tl;dr being that linking out to all these other topics is likely going to be misleading/confusing to participants of Hacktoberfest, as none of these additional topics are endorsed or tracked by Hacktoberfest, so contributions to repositories using them may not be counted if they do not have the `hacktoberfest` topic itself. Further, most of the topics that were added here are essentially not used, with almost all returning less than 5 repositories in their results.

Please see each commit for further justification/explanation for the changes within.

With these changes made, the only remaining links out in the topic description are to the language filters -- the dropdown for this is right below the description on the topic page, so honestly I somewhat feel those links are also redundant, but I have left them in for now.