### PR TITLE
add `minecraft-modpack` alias to `minecraft-mod`

### DIFF
--- a/topics/minecraft-mod/index.md
+++ b/topics/minecraft-mod/index.md
@@ -1,5 +1,5 @@
 ---
-aliases: minecraft-modding
+aliases: minecraft-modding, minecraft-modpack
 display_name: Minecraft Mod
 logo: minecraft-mod.png
 related: minecraft, minecraft-plugin, minecraft-addon


### PR DESCRIPTION
<!-- Thank you for contributing! -->
### Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: <https://github.com/github/explore/blob/main/CONTRIBUTING.md>.
- [x] I am not the sole author or employee of a company who created the topic or collection I am changing.

### Which change are you proposing?

  - [x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [ ] Something that does not neatly fit into the binary options above

---

<!-- ⚠️ Please select either this section... ⚠️ -->
### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288, size <= 75 kB)
- [x] Content (and my changes are in `index.md`)

The `minecraft-modpack` topic has 324 repositories, and `minecraft-modpack` clearly belongs with `minecraft-mod`.


---

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**
