### PR TITLE
Add Qt6 as an alias for Qt

### DIFF
--- a/topics/qt/index.md
+++ b/topics/qt/index.md
@@ -1,5 +1,5 @@
 ---
-aliases: qt-framework, qt-application, qt5
+aliases: qt-framework, qt-application, qt5, qt6
 created_by: Haavard Nord, Eirik Chambe-Eng
 display_name: Qt
 github_url: https://github.com/qt


### PR DESCRIPTION
<!-- Thank you for contributing! -->
### Please confirm this pull request meets the following requirements:

- [X] I followed the contributing guidelines: <https://github.com/github/explore/blob/main/CONTRIBUTING.md>.
- [X] I am not the sole author or employee of a company who created either the topic I am modifying/adding or the collection entry I am modifying/adding.

### Which change are you proposing?

  - [X] Suggesting edits to an existing topic or collection

---

<!-- ⚠️ Please select either this section... ⚠️ -->
### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [X] Content (and my changes are in `index.md`)

> Qt5 is already an alias for Qt. This suggests Qt6 should be as well.

> This adds Qt6 as an alias to the existing Qt topic.

---

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**
