### PR TITLE
add SponsorBlock & JumpCutter

### DIFF
--- a/collections/productivity-tools/index.md
+++ b/collections/productivity-tools/index.md
@@ -39,6 +39,8 @@ items:
  - eza-community/eza
  - bensadeh/tailspin
  - logdyhq/logdy-core
+ - ajayyy/SponsorBlock
+ - WofWca/jumpcutter
 display_name: Software productivity tools
 created_by: holman
 ---


### PR DESCRIPTION
<!-- Thank you for contributing! -->
### Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: <https://github.com/github/explore/blob/main/CONTRIBUTING.md>.
- [x] I am not the sole author or employee of a company who created either the topic I am modifying/adding or the collection entry I am modifying/adding.

### Which change are you proposing?

  - [x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [ ] Something that does not neatly fit into the binary options above

---

<!-- ⚠️ Please select either this section... ⚠️ -->
### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288, size <= 75 kB)
- [x] Content (and my changes are in `index.md`)

The Sponsor block and Jump cutter save me a lot of time.

Sponsor block let me skip ads and "integrations" segments embedded in video. According to their stats, i've save 11 days of live for users of Sponsor block:

```
 You've saved people from 7,409 segments
( 11d 17h 25.2 minutes of their lives )

You've skipped 2,596 segments ( 2d 9h 16.9 minutes ) 
```

Jump cutter does not have stats, but i think i saved a lot of time on jumps a video fragments with quiet.

So this both browser extension literally save my time. I want to invest couple minutes to add them into public list to share with other people.

---

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**
