### PR TITLE
Fix malformed list that was causing imports to fail

### DIFF
--- a/collections/playdate-rust/index.md
+++ b/collections/playdate-rust/index.md
@@ -3,21 +3,22 @@ display_name: Playdate in Rust
 created_by: boozook
 image: playdate-rust.png
 items:
- - https://sdk.play.date/Inside%20Playdate%20with%20C.html
- - pd-rs/crankstart
- - boozook/playdate
- - adamsoutar/playboy
- - jcornaz/play-jam-4
- - fum1h1ro/PlaydateRustTemplate
- - danakj/craydate
- - rusty-crank/playdate-rs
- - rusty-crank/Dino
- - bravely/nine_lives
- - pomettini/ggj-2024
- - pomettini/falling-sand-playdate
- - pomettini/starfield-playdate-rs
- - sayhiben/awesome-playdate
- - https://devforum.play.date
- - https://playdate-wiki.com/wiki/Developing_for_Playdate
+  - https://sdk.play.date/Inside%20Playdate%20with%20C.html
+  - pd-rs/crankstart
+  - boozook/playdate
+  - adamsoutar/playboy
+  - jcornaz/play-jam-4
+  - fum1h1ro/PlaydateRustTemplate
+  - danakj/craydate
+  - rusty-crank/playdate-rs
+  - rusty-crank/Dino
+  - bravely/nine_lives
+  - pomettini/ggj-2024
+  - pomettini/falling-sand-playdate
+  - pomettini/starfield-playdate-rs
+  - sayhiben/awesome-playdate
+  - https://devforum.play.date
+  - https://playdate-wiki.com/wiki/Developing_for_Playdate
 ---
+
 Packages, tools, and examples that are helpful to make games for Playdate in the Rust programming language.


### PR DESCRIPTION
This list needed an extra indent level. 

prettier caught this - wonder why it didn't fail lint in ci?
