### PR TITLE
Add kaplayjs/kaplay to JavaScript game engines

### DIFF
--- a/collections/javascript-game-engines/index.md
+++ b/collections/javascript-game-engines/index.md
@@ -20,7 +20,7 @@ items:
  - mrdoob/three.js
  - phoboslab/Impact
  - cloud9c/taro
- - replit/kaboom
+ - kaplayjs/kaplay
  - straker/kontra
  - quinton-ashley/p5play
 display_name: JavaScript Game Engines


### PR DESCRIPTION
<!-- Thank you for contributing! -->
### Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: <https://github.com/github/explore/blob/main/CONTRIBUTING.md>.
- [x] I am not the sole author or employee of a company who created either the topic I am modifying/adding or the collection entry I am modifying/adding.

### Which change are you proposing?

  - [x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [ ] Something that does not neatly fit into the binary options above

---

<!-- ⚠️ Please select either this section... ⚠️ -->
### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288, size <= 75 kB)
- [x] Content (and my changes are in `index.md`)

I added KAPLAY replacing replit/kaboom due to it's deprecation, also being [KAPLAY mentioned on now replit/kaboom repo ](https://github.com/replit/kaboom?tab=readme-ov-file#notice)

---
