### PR TITLE
Removed Pyxel game engine

### DIFF
--- a/collections/pixel-art-tools/index.md
+++ b/collections/pixel-art-tools/index.md
@@ -6,7 +6,6 @@ items:
  - maierfelix/poxi/
  - gmattie/Data-Pixels/
  - vsmode/pixel8
- - kitao/pyxel
  - jackschaedler/goya
  - cloudhead/rx
  - Orama-Interactive/Pixelorama


### PR DESCRIPTION
<!-- Thank you for contributing! -->
### Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: <https://github.com/github/explore/blob/main/CONTRIBUTING.md>.
- [x] I am not the sole author or employee of a company who created either the topic I am modifying/adding or the collection entry I am modifying/adding.

### Which change are you proposing?

  - [x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [ ] Something that does not neatly fit into the binary options above

---

<!-- ⚠️ Please select either this section... ⚠️ -->
### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288, size <= 75 kB)
- [x] Content (and my changes are in `index.md`)

Looks like the Pyxel game engine was mistaken for the PyxelEdit pixel art software, which is not opensource. So I removed it, as the game engine is not a "Pixel Art Tool".

---

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**
