### PR TITLE
Handle not found errors

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -88,6 +88,8 @@ class NewOctokit < Octokit::Client
   rescue Octokit::TooManyRequests
     repos[:skip_requests] = true
     repos[item] = true
+  rescue Octokit::NotFound
+    repos[item] = nil
   end
 
   def user(item)


### PR DESCRIPTION
Return `nil` when a repository is not found rather than raise an octokit error
