### PR TITLE
Disable topic checker workflow for now

### DIFF
--- a/.github/workflows/topic-commenter.yml
+++ b/.github/workflows/topic-commenter.yml
@@ -1,9 +1,12 @@
 name: Topic PR Commenter
 
+# this workflow is failing due to permissions problems
+# until we can fix it with a better bot, i'll preserve
+# the code but make it so it never matches a real path
 on:
   pull_request:
     paths:
-      - 'topics/**'
+      - 'ENOSUCHPATH'
 
 permissions:
   contents: read


### PR DESCRIPTION
This unfortunately needs permissions it can't easily get,
in order to run on non-maintainer-submitted PRs. Disabling
until we can work through this in a better way.

<!-- Thank you for contributing! -->
### Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: <https://github.com/github/explore/blob/main/CONTRIBUTING.md>.
- [x] I am not the sole author or employee of a company who created either the topic I am modifying/adding or the collection entry I am modifying/adding.

### Which change are you proposing?

  - [ ] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [x] Something that does not neatly fit into the binary options above

