### PR TITLE
Adds Stride3D, the open-source c# game engine

### DIFF
--- a/collections/game-engines/index.md
+++ b/collections/game-engines/index.md
@@ -1,6 +1,7 @@
 ---
 items:
  - godotengine/godot
+ - stride3d/stride
  - turbulenz/turbulenz_engine
  - TorqueGameEngines/Torque3D
  - TorqueGameEngines/Torque2D


### PR DESCRIPTION
<!-- Thank you for contributing! -->
### Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: <https://github.com/github/explore/blob/main/CONTRIBUTING.md>.
- [x] This change is not self-promotion.

### Which change are you proposing?

  - [x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [ ] Something that does not neatly fit into the binary options above

---

<!-- ⚠️ Please select either this section... ⚠️ -->
### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288, size <= 75 kB)
- [x] Content (and my changes are in `index.md`)

Stride is one of the largest non-profit open-source game engines, and I was surprised it was missing from this collection.

Adds the repo [`stride3d/stride`](https://github.com/stride3d/stride) to the list.
