### PR TITLE
Removing irrelevant `Sports game` alias

### DIFF
--- a/topics/sports-game/index.md
+++ b/topics/sports-game/index.md
@@ -1,7 +1,7 @@
 ---
 display_name: sports-game
 topic: sports-game
-related: sports
+related: sports, video-games, games
 short_description: A genre of video game.
 wikipedia_url: https://en.wikipedia.org/wiki/Sports_game
 ---

--- a/topics/sports-game/index.md
+++ b/topics/sports-game/index.md
@@ -1,7 +1,7 @@
 ---
 display_name: sports-game
 topic: sports-game
-aliases: sports
+related: sports
 short_description: A genre of video game.
 wikipedia_url: https://en.wikipedia.org/wiki/Sports_game
 ---


### PR DESCRIPTION
### Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: <https://github.com/github/explore/blob/main/CONTRIBUTING.md>.
- [x] This change is not self-promotion.

### Which change are you proposing?

  - [x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [ ] Something that does not neatly fit into the binary options above

---

### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288, size <= 75 kB)
- [x] Content (and my changes are in `index.md`)

I removed the irrelevant `sports` alias of the `sports-game`, as `sports` covers a very much broader set of topics, not only video games about sports. (Also useful for PR #4814 which adds the `sports` topic.)

I also added two relevant related topics : `sports` and `games`.