### PR TITLE
Fix incorrect Wikipedia link for ZX Spectrum

### DIFF
--- a/topics/zx-spectrum/index.md
+++ b/topics/zx-spectrum/index.md
@@ -4,7 +4,7 @@ topic: zx-spectrum
 aliases: spectrum, speccy, spectrum-zx, zxspectrum, spectrumzx, sinclair, sinclair-spectrum
 related: amstrad-cpc, commodore-64, bbc-micro, spectrum-next
 short_description: An 8-bit personal home computer developed by Sinclair Research and Britain's best-selling microcomputer.
-wikipedia_url: https://en.wikipedia.org/wiki/Action-adventure_game
+wikipedia_url: https://en.wikipedia.org/wiki/ZX_Spectrum
 created_by: Sinclair Research
 released: April 23, 1982
 logo: zx-spectrum.png


### PR DESCRIPTION
<!-- Thank you for contributing! -->
### Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: <https://github.com/github/explore/blob/main/CONTRIBUTING.md>.
- [x] This change is not self-promotion.

### Which change are you proposing?

  - [x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [ ] Something that does not neatly fit into the binary options above

---

<!-- ⚠️ Please select either this section... ⚠️ -->
### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288, size <= 75 kB)
- [x] Content (and my changes are in `index.md`)

The Wikipedia article URL for the ZX Spectrum is wrong; it actually goes to the article about action-adventure games. This PR replaces it with the correct URL.
