### PR TITLE
Update programming-languages collection to allow more projects to join

### DIFF
--- a/collections/programming-languages/index.md
+++ b/collections/programming-languages/index.md
@@ -76,4 +76,5 @@ items:
 display_name: Programming languages
 created_by: leereilly
 ---
-A list of programming languages that are actively developed on GitHub
+
+A list of actively developed programming languages that are found on GitHub.


### PR DESCRIPTION
*(As a side note which for lack of another communication channel I'm putting here, you seem to require `Signed-off-by` for your commits, but seemingly [the notices have no info](https://github.com/github/explore/blob/4e090821fdddd73a7ccf4e0436e8e89f6cc668ac/notices.md)  on what that means. You don't seem to be using something like the common "Developer Certificate of Origin" for example. I'd like to point out that at least to me, the sign off seems to be ambiguous and potentially pointless, since I feel like it's not really clear what that means to anybody. If it's to accept the licensing and to certify that I wrote the commit, then perhaps the notices should point that out. However, I could be wrong, I'm not a lawyer.)*

<!-- Thank you for contributing! -->
### Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: <https://github.com/github/explore/blob/main/CONTRIBUTING.md>.
- [x] This change is not self-promotion.

### Which change are you proposing?

  - [x] Suggesting edits to an existing topic or collection
  - [ ] Curating a new topic or collection
  - [ ] Something that does not neatly fit into the binary options above

---

<!-- ⚠️ Please select either this section... ⚠️ -->
### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:
- [ ] Image (and my file is `*.png`, square, dimensions 288x288, size <= 75 kB)
- [ ] Content (and my changes are in `index.md`)
- [x] Description

I'm suggesting that the collection description allow languages that are still actively developed but where their Github presence might be, while up-to-date, secondary and not where issues are tracked.

I'm suggesting this change because:

- None of the other collections have the requirement in the description for their Github repository to be the main repository.

- This collection already has entries like https://github.com/TinyCC/tinycc that don't fulfill this constraint.

- In the light of [some](https://github.com/orgs/community/discussions/159749) [recent](https://github.com/orgs/community/discussions/148571) Github decisions, perhaps projects shouldn't be discouraged from using Github as a secondary presence rather than primary.

<!-- ⚠️ this section... ⚠️ -->
### Curating a new topic or collection

- [ ] I've formatted my changes as a new folder directory, named for the topic or collection as it appears in the URL on GitHub (e.g. `https://github.com/topics/[NAME]` or `https://github.com/collections/[NAME]`)
- [ ] My folder contains a `*.png` image (if applicable) and `index.md`
- [ ] All required fields in my `index.md` conform to the Style Guide and API docs: <https://github.com/github/explore/tree/main/docs>

> Please replace this line with an explanation of why you think this topic or collection should be curated.

<!-- ⚠️ ... or this section ⚠️ -->
### Something that does not neatly fit into the binary options above

- [ ] My suggested edits are not about an existing topic or collection, or at least not a single one
- [ ] My suggested edits are not about curating a new topic or collection, or at least not a single one
- [ ] My suggested edits conform to the Style Guide and API docs: https://github.com/github/explore/tree/main/docs

> Please replace this line with an explanation of your proposed changes.

---


