### PR TITLE
Add topic: ai-agent

### DIFF
--- a/topics/ai-agent/index.md
+++ b/topics/ai-agent/index.md
@@ -1,0 +1,17 @@
+---
+aliases: agent-harnesses, ai-agent-harness, llm-harness
+display_name: Agent Harness
+short_description: Runtime infrastructure that connects LLMs to real-world tools, memory, and execution environments.
+topic: agent-harness
+related:
+  - ai-agent
+  - orchestration
+  - tool-use
+  - mcp
+  - llm
+---
+<!-- markdownlint-disable MD041 -->
+
+An **agent harness** is the runtime layer between a large language model and the outside world. It manages the agentic loop — prompt the model, parse tool calls, execute tools, feed results back — while enforcing permissions, compressing context, and handling error recovery. The term gained traction after Anthropic's Claude Code source was studied, revealing the internal architecture that turns a text-generating LLM into a capable software-engineering agent.
+
+Agent harness projects include full runtime environments (LobeHub, oh-my-agent, HexAgent, Utah), agent harness frameworks for Python and TypeScript (water, Chorus), code-quality agents (desloppify), portable skill systems (cc-harness-skills, oh-my-agent), research surveys (LLM-Agent-Harness-Survey), and autonomous systems with persistent memory and orchestration (Adam, Sibyl). The pattern is characterized by a tool registry, a permission system, context management, and often multi-agent coordination.


### PR DESCRIPTION
### Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: <https://github.com/github/explore/blob/main/CONTRIBUTING.md>.
- [x] This change is not self-promotion.

### Which change are you proposing?

  - [ ] Suggesting edits to an existing topic or collection
  - [x] Curating a new topic or collection
  - [ ] Something that does not neatly fit into the binary options above

---

### Curating a new topic or collection

- [x] I've formatted my changes as a new folder directory, named for the topic or collection as it appears in the URL on GitHub (e.g. `https://github.com/topics/[NAME]` or `https://github.com/collections/[NAME]`)
- [x] My folder contains a `*.png` image (if applicable) and `index.md`
- [x] All required fields in my `index.md` conform to the Style Guide and API docs: <https://github.com/github/explore/tree/main/docs>

The topic [ai-agent](https://github.com/topics/ai-agent) is used by ~8,900 repositories (plus ~20,900 under the plural alias `ai-agents`), yet has no curated description in GitHub Explore. AI agents — autonomous software systems that use foundation models to reason, plan, and act — are one of the fastest-growing categories on GitHub, spanning coding assistants, browser automation, multi-agent teams, and execution sandboxes. A curated topic page would help developers discover and contextualize this ecosystem.

No image included — no universally recognized logo exists for this general concept.