### PR TITLE
Delete YouTube video from list of repos in Government collection

### DIFF
--- a/collections/government/index.md
+++ b/collections/government/index.md
@@ -18,7 +18,6 @@ items:
  - NatLabRockies/api-umbrella
  - usds/playbook
  - republique-et-canton-de-geneve/chvote-1-0
- - https://www.youtube.com/embed/uNa9GOtM6NE
  - gchq/CyberChef
  - HSEIreland/covid-tracker-app
  - nic-delhi/AarogyaSetu_Android


### PR DESCRIPTION
<!-- Thank you for contributing! -->
### Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: <https://github.com/github/explore/blob/main/CONTRIBUTING.md>.
- [x] This change is not self-promotion.

### Which change are you proposing?

- [x] Suggesting edits to an existing topic or collection

### Editing an existing topic or collection

I'm suggesting these edits to an existing topic or collection:

- [x] Government collection: remove YouTube link from list of repos. 

A YouTube video is not a government repo. 
