### PR TITLE
Add Monoscope to DevOps tools collection

### DIFF
--- a/collections/devops-tools/index.md
+++ b/collections/devops-tools/index.md
@@ -44,6 +44,7 @@ items:
  - axem-solutions/dem
  - semaphoreio/semaphore
  - stoicsoft/server-compass-releases
+ - monoscope-tech/monoscope
  
 display_name: DevOps tools
 ---


### PR DESCRIPTION
## What is Monoscope?

[Monoscope](https://github.com/monoscope-tech/monoscope) is an open-source, self-hosted observability platform for logs, traces, and metrics. It ingests via OpenTelemetry (gRPC), stores in S3-compatible storage, and lets you query in natural language via LLMs.

- **495 stars**, actively maintained
- Written in Haskell; frontend is server-side rendered HTML + HTMX
- Designed for self-hosted deployments on top of TimescaleDB + S3
- Fits alongside Prometheus, Grafana, Sentry, and Logstash already in the collection