### PR TITLE
Fix uninterpolated ${PR_ID} in collections-renames autofix branch name

### DIFF
--- a/.github/workflows/collections-renames.yml
+++ b/.github/workflows/collections-renames.yml
@@ -35,5 +35,5 @@ jobs:
         with:
           commit-message: "✨ Autofixing renamed/removed collection items ✨"
           committer: "github-actions[bot] <actions@github.com>"
-          branch: "update-collections-${PR_ID}"
+          branch: update-collections
           title: "✨ Autofixing renamed/removed collection items ✨"


### PR DESCRIPTION
## Summary

The `branch:` input to `peter-evans/create-pull-request` in `.github/workflows/collections-renames.yml` was set to `update-collections-${PR_ID}`, but:

1. Actions inputs are not shell-interpolated.
2. No `PR_ID` env var is defined anywhere in the workflow.

So the literal string `${PR_ID}` was ending up in the branch name. You can see this on the existing autofix PR — e.g. https://github.com/github/explore/pull/5152 reports `force-pushed the update-collections-${PR_ID} branch`.

## Fix

Drop the suffix. `peter-evans/create-pull-request` is designed around a stable branch: if a PR already exists for that branch, it force-pushes new changes onto it instead of opening a new one. That matches what we want for an hourly autofix job — one rolling open PR, not a new branch every hour.

## Test plan

- [ ] Next scheduled run uses the branch `update-collections` and updates the existing autofix PR (or opens one if none is open).
- [ ] No more `${PR_ID}` literals in branch names.