### PR TITLE
Serve topic logos from explore-feed.github.com

### DIFF
--- a/feed.json.liquid
+++ b/feed.json.liquid
@@ -42,7 +42,7 @@ permalink: feed.json
         "logo": {% if topic.logo == null %}
           null,
         {% else %}
-          "https://github.com/github/explore/blob/main{{ topic.id | remove_first: "/index" }}/{{ topic.logo }}?raw=true",
+          "{{ site.url }}{{ topic.id | remove_first: "/index" }}/{{ topic.logo }}",
         {% endif %}
         "released": {{ topic.released | jsonify }},
         "short_description": {{ topic.short_description | jsonify }},


### PR DESCRIPTION
## Summary

The topics block in `feed.json.liquid` emits logo URLs pointing at `https://github.com/github/explore/blob/main/.../...?raw=true`. github/github's CSP `img-src` doesn't allow `github.com` as an arbitrary image host, so on admin views like https://admin.github.com/biztools/topics the topic logos fail to render.

The collections block right above already uses `{{ site.url }}` (which is `https://explore-feed.github.com` per `CNAME`) — switch the topics block to the same pattern so logos are served from the same canonical asset host as collection images.

## Companion change

A companion PR in `github/github` adds `explore-feed.github.com` to the CSP `img-src` allowlist (alongside the existing `customer-stories-feed.github.com` and `spotlights-feed.github.com` entries). Either PR can land first — neither host works today.

## Test plan

- [ ] After this is published, hit `https://explore-feed.github.com/feed.json` and confirm topic `logo` URLs are prefixed with `https://explore-feed.github.com/...` (no more `github.com/.../blob/main/...?raw=true`).
- [ ] Once the github/github CSP PR also ships, confirm topic logos render on `https://admin.github.com/biztools/topics`.