### PR TITLE
Add mcp topic

### DIFF
--- a/topics/mcp/index.md
+++ b/topics/mcp/index.md
@@ -1,0 +1,21 @@
+---
+display_name: MCP
+topic: mcp
+aliases:
+  - model-context-protocol
+related:
+  - mcp-server
+  - ai-agent
+  - llm
+  - agent-harness
+short_description: Model Context Protocol (MCP) is an open standard for connecting AI models to external tools and data sources.
+created_by: Anthropic
+url: https://modelcontextprotocol.io
+released: November 2024
+---
+
+Model Context Protocol (MCP) is an open standard that defines how AI applications connect to external tools, data sources, and services. MCP uses a client-server architecture where AI-powered applications (clients) communicate with lightweight programs (servers) that expose specific capabilities through a standardized interface.
+
+MCP servers can provide tools (executable functions), resources (read-only data), and prompts (reusable templates). The protocol supports multiple transport mechanisms including stdio for local processes and HTTP with Server-Sent Events for remote connections.
+
+The protocol was created by Anthropic and released as an open specification. It is supported by AI tools including Claude Code, Cursor, Codex, Windsurf, and Claude Desktop.

--- a/topics/mcp/index.md
+++ b/topics/mcp/index.md
@@ -1,13 +1,8 @@
 ---
 display_name: MCP
 topic: mcp
-aliases:
-  - model-context-protocol
-related:
-  - mcp-server
-  - ai-agent
-  - llm
-  - agent-harness
+aliases: model-context-protocol
+related: mcp-server, ai-agent, llm, agent-harness
 short_description: Model Context Protocol (MCP) is an open standard for connecting AI models to external tools and data sources.
 created_by: Anthropic
 url: https://modelcontextprotocol.io


### PR DESCRIPTION
## Checklist

**For all pull requests:**

- [x] I have read the [contributing guidelines](https://github.com/github/explore/blob/main/CONTRIBUTING.md).
- [x] This pull request is making changes to one topic or collection only.
- [x] This pull request is not a duplicate of an existing pull request.
- [x] I am not promoting my own project — MCP is an open protocol by Anthropic used by 34,000+ repositories.

**For new topics or collections:**

- [x] I have searched to make sure this topic or collection does not already exist.
- [x] This topic or collection name meets the [naming criteria](https://github.com/github/explore/blob/main/CONTRIBUTING.md#naming-criteria).

## Description

Add a curated topic page for **MCP (Model Context Protocol)**, an open standard for connecting AI models to external tools and data sources.

- **34,595 repositories** currently use the `mcp` topic on GitHub, but no curated topic page exists.
- MCP was created by Anthropic and released as an open specification in November 2024.
- The protocol is supported by major AI tools including Claude Code, Cursor, Codex, and Windsurf.
- The related topic `msp-mcp` was recently merged (#5139), and the `ai-agent` topic references MCP in its description.

This is a neutral, community-oriented topic definition for a widely-used open protocol.