### PR TITLE
Add mcp-server topic

### DIFF
--- a/topics/mcp-server/index.md
+++ b/topics/mcp-server/index.md
@@ -1,0 +1,19 @@
+---
+display_name: MCP Server
+topic: mcp-server
+aliases:
+  - mcp-servers
+related:
+  - mcp
+  - model-context-protocol
+  - ai-agent
+  - llm
+short_description: MCP servers expose tools, resources, and prompts to AI applications through the Model Context Protocol.
+url: https://modelcontextprotocol.io
+---
+
+MCP servers are lightweight programs that expose specific capabilities to AI applications through the Model Context Protocol (MCP). Each server acts as a bridge between AI models and external systems, providing tools (executable functions), resources (read-only data), and prompts (reusable templates) through a standardized interface.
+
+MCP servers communicate with AI-powered clients over stdio for local processes or HTTP with Server-Sent Events for remote connections. They can integrate with databases, APIs, file systems, development tools, and cloud services. A single AI application can connect to multiple MCP servers simultaneously.
+
+The MCP server ecosystem includes registries such as the official MCP Registry, Glama, and Smithery, where developers publish and discover servers for specific use cases.

--- a/topics/mcp-server/index.md
+++ b/topics/mcp-server/index.md
@@ -1,13 +1,8 @@
 ---
 display_name: MCP Server
 topic: mcp-server
-aliases:
-  - mcp-servers
-related:
-  - mcp
-  - model-context-protocol
-  - ai-agent
-  - llm
+aliases: mcp-servers
+related: mcp, model-context-protocol, ai-agent, llm
 short_description: MCP servers expose tools, resources, and prompts to AI applications through the Model Context Protocol.
 url: https://modelcontextprotocol.io
 ---


### PR DESCRIPTION
## Checklist

**For all pull requests:**

- [x] I have read the [contributing guidelines](https://github.com/github/explore/blob/main/CONTRIBUTING.md).
- [x] This pull request is making changes to one topic or collection only.
- [x] This pull request is not a duplicate of an existing pull request.
- [x] I am not promoting my own project — MCP servers are a general concept from the open MCP ecosystem.

**For new topics or collections:**

- [x] I have searched to make sure this topic or collection does not already exist.
- [x] This topic or collection name meets the [naming criteria](https://github.com/github/explore/blob/main/CONTRIBUTING.md#naming-criteria).

## Description

Add a curated topic page for **MCP Server**, the server-side component of the Model Context Protocol ecosystem.

- **16,047 repositories** currently use the `mcp-server` topic on GitHub, but no curated topic page exists.
- MCP servers are lightweight programs that expose tools, resources, and prompts to AI applications.
- The related `mcp` topic (34,595 repos) also lacks a curated page — a separate PR is being submitted for that.
- The recently merged `ai-agent` topic (#5116) and `msp-mcp` topic (#5139) reference MCP concepts, confirming community relevance.

This is a neutral, community-oriented topic definition for a widely-used open standard component.