### PR TITLE
Add loop-engineering topic

### DIFF
--- a/topics/loop-engineering/index.md
+++ b/topics/loop-engineering/index.md
@@ -2,7 +2,7 @@
 aliases: agent-loops, agentic-loops
 display_name: Loop Engineering
 related: ai-agents, llm, agentic-ai, automation, prompt-engineering
-short_description: Designing recurring AI and coding-agent systems that discover work, verify results, persist state, and re-run over time.
+short_description: Designing recurring AI and coding agent systems that discover work, verify results, persist state, and re-run over time.
 topic: loop-engineering
 ---
-Loop Engineering is the practice of designing recurring AI-agent and coding-agent systems. Instead of prompting an agent turn by turn, you build a loop that discovers work, delegates it to one or more agents, verifies the result against tests or other deterministic gates, persists state outside the model, decides what happens next, and runs again on a cadence, an event, or until a verifiable goal is reached. It sits above prompt, context, and harness engineering: those improve a single run, while loop engineering governs repeated agent work over time, including budgets, retries, escalation to humans, and stopping conditions.
+Loop Engineering is the practice of designing recurring systems for AI agents and coding agents. Instead of prompting an agent turn by turn, you build a loop that discovers work, delegates it to one or more agents, verifies the result against tests or other deterministic gates, persists state outside the model, decides what happens next, and runs again on a cadence, an event, or until a verifiable goal is reached. It sits above prompt, context, and harness engineering: those improve a single run, while loop engineering governs repeated agent work over time, including budgets, retries, escalation to humans, and stopping conditions.

--- a/topics/loop-engineering/index.md
+++ b/topics/loop-engineering/index.md
@@ -1,0 +1,8 @@
+---
+aliases: agent-loops, agentic-loops
+display_name: Loop Engineering
+related: ai-agents, llm, agentic-ai, automation, prompt-engineering
+short_description: Designing recurring AI and coding-agent systems that discover work, verify results, persist state, and re-run over time.
+topic: loop-engineering
+---
+Loop Engineering is the practice of designing recurring AI-agent and coding-agent systems. Instead of prompting an agent turn by turn, you build a loop that discovers work, delegates it to one or more agents, verifies the result against tests or other deterministic gates, persists state outside the model, decides what happens next, and runs again on a cadence, an event, or until a verifiable goal is reached. It sits above prompt, context, and harness engineering: those improve a single run, while loop engineering governs repeated agent work over time, including budgets, retries, escalation to humans, and stopping conditions.


### PR DESCRIPTION
## What this does

Adds a curated topic page for **loop-engineering**.

## Why it is valuable

Loop Engineering is an emerging AI/coding-agent practice: designing recurring systems that discover work, delegate to agents, verify results, persist state, and re-run over time (above prompt, context, and harness engineering). The `loop-engineering` topic is already applied to ~90 public repositories, but there is no curated description yet, so the topic page currently shows no explanation of the term.

This page gives a concise, neutral definition and links related topics (ai-agents, llm, agentic-ai, automation, prompt-engineering).

## Checklist

- [x] Limited to creating one topic.
- [x] Topic name matches the URL (`https://github.com/topics/loop-engineering`).
- [x] Short description and body are neutral and descriptive.
- [x] No logo included (happy to add one if preferred).