### PR TITLE
Update Made in Iran collection by removing an entry

### DIFF
--- a/collections/made-in-iran/index.md
+++ b/collections/made-in-iran/index.md
@@ -22,7 +22,6 @@ items:
  - majidh1/JalaliDatePicker
  - mojtaba-afraz/clean-code-persian
  - iw4p/partialjson
- - persian-calendar/persian-calendar
 display_name: Made in Iran
 created_by: Javad
 image: made-in-iran.png


### PR DESCRIPTION
Removed 'persian-calendar/persian-calendar' from the list.

I want to revert the changes I made a few days ago. I realized that this calendar is not actually made in Iran, and the developer is based in the United States.
