### PR TITLE
Curate the agent-skills topic

### DIFF
--- a/topics/agent-skills/index.md
+++ b/topics/agent-skills/index.md
@@ -1,0 +1,10 @@
+---
+aliases: agent-skill, ai-agent-skills
+display_name: Agent Skills
+related: agent-harness, ai-agents, coding-agents, mcp, claude-code, prompt-engineering
+short_description: Agent skills are reusable bundles of instructions and resources that an AI agent loads on demand.
+topic: agent-skills
+---
+Agent skills are self-contained bundles of instructions, reference material, and scripts that an AI agent loads only when a task calls for them. A skill declares what it covers and when it applies, so the agent decides for itself whether to pull it into context instead of carrying every instruction at all times.
+
+The pattern lets an agent's capabilities grow without its working context growing with them. Authors publish skills as plain files in a repository, and users install the ones they need. Agent skills are commonly paired with agent harnesses and the Model Context Protocol, and are used to capture coding conventions, design systems, domain workflows, and organization-specific procedures.


### PR DESCRIPTION
### Please confirm this pull request meets the following requirements:

- [x] I followed the contributing guidelines: <https://github.com/github/explore/blob/main/CONTRIBUTING.md>.
- [x] This change is not self-promotion.

### Which change are you proposing?

  - [ ] Suggesting edits to an existing topic or collection
  - [x] Curating a new topic or collection
  - [ ] Something that does not neatly fit into the binary options above

---

### Curating a new topic or collection

- [x] I've formatted my changes as a new folder directory, named for the topic or collection as it appears in the URL on GitHub (`https://github.com/topics/agent-skills`)
- [x] My folder contains a `*.png` image (if applicable) and `index.md`
- [x] All required fields in my `index.md` conform to the Style Guide and API docs: <https://github.com/github/explore/tree/main/docs>

`agent-skills` currently has roughly 14,600 repositories and no curated page, so https://github.com/topics/agent-skills renders with no description and — more importantly — no Related Topics box. There is no lateral path between it and the neighbouring topics that are already curated (`agent-harness`, `mcp`, `claude-code`, `prompt-engineering`), even though they describe adjacent parts of the same stack.

The term is also ambiguous enough to be worth defining. "Skill" is heavily overloaded in this space, and repositories under this topic range from single instruction files to full tooling. The description here sticks to what the pattern actually is — instructions and resources an agent loads on demand — without naming any particular vendor's implementation, since several exist.

I've followed the shape of `topics/agent-harness/index.md`, which is the closest existing precedent: front-matter limited to `aliases`, `display_name`, `related`, `short_description` and `topic`, with no `created_by`, `url` or `github_url`, because this is a general pattern rather than one project. `short_description` is 97 characters and the body is 702.

No image included — I don't have one that would be appropriate or that I hold the rights to.

For disclosure: I publish repositories that carry this topic. This page links to none of them and names no products.