### PR TITLE
Restore fork PR triage writer comments

### DIFF
--- a/.github/workflows/explore-triage-commenter-writer.yml
+++ b/.github/workflows/explore-triage-commenter-writer.yml
@@ -8,7 +8,7 @@ on:
 permissions:
   actions: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: explore-triage-commenter-writer-${{ github.event.workflow_run.head_repository.full_name || github.event.workflow_run.head_sha }}-${{ github.event.workflow_run.head_branch || github.event.workflow_run.head_sha }}
@@ -110,7 +110,7 @@ jobs:
 
       - name: Upsert sticky comment
         if: steps.artifact.outputs.found == 'true'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           COMMENT_DATA_PATH: ${{ runner.temp }}/explore-triage/comment.json
           MARKER: '<!-- explore-triage-comment -->'


### PR DESCRIPTION
## Summary

- grant the Explore triage writer `pull-requests: write` so it can create and update comments for fork pull requests after the PRT migration
- pin `actions/github-script` v9 to its immutable upstream commit SHA
- keep the existing artifact size, schema, workflow run, repository, branch, head-SHA, and pull-request association trust-boundary validation unchanged

## Validation

- `actionlint .github/workflows/explore-triage-commenter-writer.yml`
- targeted assertions for the writer permission, immutable action pin, and retained trust-boundary checks