### PR TITLE
Add curated topic definition for web-scraping

### DIFF
--- a/topics/web-scraping/index.md
+++ b/topics/web-scraping/index.md
@@ -1,0 +1,10 @@
+---
+display_name: Web Scraping
+topic: web-scraping
+aliases: scraping, webscraping
+related: browser-automation, headless-browser, puppeteer, playwright, selenium
+short_description: Web scraping is the automated extraction of structured data from websites.
+---
+Web scraping is the process of programmatically retrieving web pages and extracting structured data from them for analysis, storage, or reuse. It powers price monitoring, search indexing, market research, and training-data collection.
+
+Scraping ranges from plain HTTP requests and HTML parsing to full browser automation for JavaScript-rendered and anti-bot-protected pages. The ecosystem includes request libraries, HTML parsers, headless browsers, and cloud extraction platforms.


### PR DESCRIPTION
Curates the `web-scraping` topic — one of the largest topics without a curated definition, at roughly 18,000 repositories.

[aginxbrowser](https://github.com/yinnho/aginxbrowser) — a server-side browser engine exposed over HTTP and MCP — is one of the repositories tagged here.