### PR TITLE
Add curated topic definition for browser-automation

### DIFF
--- a/topics/browser-automation/index.md
+++ b/topics/browser-automation/index.md
@@ -1,0 +1,10 @@
+---
+display_name: Browser Automation
+topic: browser-automation
+aliases: web-automation, browser-testing
+related: headless-browser, web-scraping, puppeteer, playwright, selenium, mcp
+short_description: Browser automation drives a web browser programmatically to test, scrape, and interact with websites.
+---
+Browser automation controls a web browser through code to perform tasks a person would otherwise do by hand: navigating, clicking, filling forms, and reading the resulting pages. It underpins end-to-end testing, web scraping, and agent-driven browsing.
+
+The field spans browser-level protocols such as the Chrome DevTools Protocol and WebDriver, higher-level libraries such as Puppeteer and Playwright, and purpose-built headless engines exposed over HTTP or MCP.


### PR DESCRIPTION
Curates the `browser-automation` topic — roughly 3,500 repositories with no curated definition yet.

[aginxbrowser](https://github.com/yinnho/aginxbrowser) — a server-side browser engine exposed over HTTP and MCP — is one of the repositories tagged here.