### PR TITLE
Add curated topic definition for headless-browser

### DIFF
--- a/topics/headless-browser/index.md
+++ b/topics/headless-browser/index.md
@@ -1,0 +1,10 @@
+---
+display_name: Headless Browser
+topic: headless-browser
+aliases: headless-browsers, headless
+related: browser-automation, web-scraping, puppeteer, playwright, chromium
+short_description: A headless browser runs a full web engine without a visible window for automation, scraping, and server-side rendering.
+---
+Headless browsers run a complete browser engine — HTML parsing, CSS layout, JavaScript execution, and rendering — without a graphical interface. They power server-side web scraping, automated testing, screenshot generation, and agent tools that read and act on the web.
+
+Headless operation trades a visible window for the ability to run many browser instances cheaply in containers and CI pipelines, often driving them over protocols such as CDP, WebDriver, or MCP.


### PR DESCRIPTION
Curates the `headless-browser` topic — roughly 400 repositories with no curated definition yet.

[aginxbrowser](https://github.com/yinnho/aginxbrowser) — a server-side browser engine exposed over HTTP and MCP — is one of the repositories tagged here.