### PR TITLE
Add dsh-plugin topic page

### DIFF
--- a/topics/dsh-plugin/index.md
+++ b/topics/dsh-plugin/index.md
@@ -8,7 +8,3 @@ topic: dsh-plugin
 DeepSeek Harness (DSH) is an agentic, plugin-based software development harness. The *dsh-plugin* topic gathers third-party plugins that extend it with new host capabilities, agent tools, connectors, and custom web settings UI.
 
 A plugin typically ships a host bundle plus an optional client section, and registers into the harness through Cordis. Explore the community ecosystem:
-
-- [dsh-marketplace](https://github.com/ouyangyipeng/dsh-marketplace) — a live, safe plugin marketplace for DeepSeek Harness
-- [awesome-dsh-list](https://github.com/kingselyjoe/awesome-dsh-list) — a ranked index of DeepSeek Harness tools
-- [awesome-dsh-plugin](https://github.com/wgd753/awesome-dsh-plugin) — an automated plugin directory with machine-readable data

--- a/topics/dsh-plugin/index.md
+++ b/topics/dsh-plugin/index.md
@@ -1,0 +1,14 @@
+---
+display_name: DeepSeek Harness Plugins
+related: deepseek, ai, llm, agent
+short_description: Third-party plugins that extend the DeepSeek Harness (DSH) agentic coding platform with tools, connectors, and custom UI.
+topic: dsh-plugin
+---
+
+DeepSeek Harness (DSH) is an agentic, plugin-based software development harness. The *dsh-plugin* topic gathers third-party plugins that extend it with new host capabilities, agent tools, connectors, and custom web settings UI.
+
+A plugin typically ships a host bundle plus an optional client section, and registers into the harness through Cordis. Explore the community ecosystem:
+
+- [dsh-marketplace](https://github.com/ouyangyipeng/dsh-marketplace) — a live, safe plugin marketplace for DeepSeek Harness
+- [awesome-dsh-list](https://github.com/kingselyjoe/awesome-dsh-list) — a ranked index of DeepSeek Harness tools
+- [awesome-dsh-plugin](https://github.com/wgd753/awesome-dsh-plugin) — an automated plugin directory with machine-readable data


### PR DESCRIPTION
Adds a curated page for the `dsh-plugin` GitHub topic (DeepSeek Harness plugins) so developers can more easily discover the ecosystem.

- `display_name`: DeepSeek Harness Plugins
- `short_description` (121 chars) + longer body describing the plugin model
- `related`: deepseek, ai, llm, agent
- Community links: dsh-marketplace, awesome-dsh-list, awesome-dsh-plugin
- Logo omitted per the topic contribution guideline (no official logo exists).